### PR TITLE
Android: after resizing a newly captured image, delete the original image

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -438,6 +438,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       }
       else
       {
+        // Newly captured images should only leave one copy on disk.
+        if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) { 
+          imageConfig.original.delete();
+        }
         uri = Uri.fromFile(imageConfig.resized);
         BitmapFactory.decodeFile(imageConfig.resized.getAbsolutePath(), options);
         responseHelper.putInt("width", options.outWidth);


### PR DESCRIPTION
- Presumably, the caller doesn't want this image, and its path and URI are not returned in the response object, so its persistence seems unintentional.
- The current behavior is likely the cause of #468.