### PR TITLE
Ensure that MediaScanner will find file saved to camera roll

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -457,6 +457,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
         imageConfig = rolloutResult.imageConfig;
         uri = Uri.fromFile(imageConfig.getActualFile());
         updatedResultResponse(uri, imageConfig.getActualFile().getAbsolutePath());
+        fileScan(reactContext, imageConfig.getActualFile().getAbsolutePath());
       }
       else
       {


### PR DESCRIPTION
## Motivation (required)

On Pixel and Samsung devices the MediaScanner wasn't running when saving an image to the camera roll, thus after taking a photo the photo could not be seen when going back into the image library.  The fix (simple enough) is to call filescan on the image saved to the camera roll.

## Test Plan (required)

Tested on the Pixel and Samsung S5.
