### PR TITLE
permissionDenied for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ IMPORTANT NOTE: You'll still need to perform step 4 for iOS and steps 2, 3, and 
     include ':react-native-image-picker'
     project(':react-native-image-picker').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-image-picker/android')
     ```
-    
+
 2. Update the android build tools version to `2.2.+` in `android/build.gradle`:
     ```gradle
     buildscript {
@@ -56,27 +56,27 @@ IMPORTANT NOTE: You'll still need to perform step 4 for iOS and steps 2, 3, and 
         ...
     }
     ...
-    ``` 
-    
+    ```
+
 3. Update the gradle version to `2.14.1` in `android/gradle/wrapper/gradle-wrapper.properties`:
     ```
     ...
     distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
     ```
-    
+
 4. Add the compile line to the dependencies in `android/app/build.gradle`:
     ```gradle
     dependencies {
         compile project(':react-native-image-picker')
     }
     ```
-    
+
 5. Add the required permissions in `AndroidManifest.xml`:
     ```xml
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     ```
-    
+
 6. Add the import and link the package in `MainApplication.java`:
     ```java
     import com.imagepicker.ImagePickerPackage; // <-- add this import
@@ -240,10 +240,11 @@ storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to
 storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`
 storageOptions.cameraRoll | OK | OK | If true, the cropped photo will be saved to the iOS Camera Roll or Android DCIM folder.
 storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this is true.
-permissionDenied.title | - | OK | Title of explaining permissions dialog. By default `Permission denied`.
-permissionDenied.text | - | OK | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.
+permissionDenied.title | OK | OK | Title of explaining permissions dialog. By default `Permission denied`.
+permissionDenied.text | OK | OK | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.
 permissionDenied.reTryTitle | - | OK | Title of re-try button. By default `re-try`
-permissionDenied.okTitle | - | OK | Title of ok button. By default `I'm sure`
+permissionDenied.settingTitle | OK | - | Title of open-settings button. By default `Open Settings`
+permissionDenied.okTitle | OK | OK | Title of ok button. By default `I'm sure`
 
 ### The Response Object
 

--- a/android/src/main/java/com/imagepicker/ResponseHelper.java
+++ b/android/src/main/java/com/imagepicker/ResponseHelper.java
@@ -73,6 +73,10 @@ public class ResponseHelper
 
     public void invokeResponse(@NonNull final Callback callback)
     {
-        callback.invoke(response);
+        try{
+            callback.invoke(response);
+        }catch (RuntimeException e){
+            //java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.
+        }
     }
 }

--- a/android/src/main/java/com/imagepicker/utils/UI.java
+++ b/android/src/main/java/com/imagepicker/utils/UI.java
@@ -87,7 +87,9 @@ public class UI
             public void onCancel(@NonNull final DialogInterface dialog)
             {
                 callback.onCancel(reference.get());
-                dialog.dismiss();
+                if(dialog != null){
+                    dialog.dismiss();
+                }
             }
         });
 

--- a/index.js
+++ b/index.js
@@ -22,16 +22,11 @@ const DEFAULT_OPTIONS = {
 module.exports = {
   ...ImagePickerManager,
   showImagePicker: function showImagePicker(options, callback) {
-    if(this.hasShow){
-      return;
-    }
-    this.hasShow = true;
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
     return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, (response)=>{
-      this.hasShow = false;
       callback&&callback(response);
     })
   }

--- a/index.js
+++ b/index.js
@@ -22,10 +22,17 @@ const DEFAULT_OPTIONS = {
 module.exports = {
   ...ImagePickerManager,
   showImagePicker: function showImagePicker(options, callback) {
+    if(this.hasShow){
+        return;
+    }
+    this.hasShow = true;
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
-    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, callback)
+    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, (response)=>{
+        this.hasShowed = false;
+        callback&&callback(response);
+    })
   }
 }

--- a/index.js
+++ b/index.js
@@ -22,17 +22,10 @@ const DEFAULT_OPTIONS = {
 module.exports = {
   ...ImagePickerManager,
   showImagePicker: function showImagePicker(options, callback) {
-    if(this.hasShow){
-        return;
-    }
-    this.hasShow = true;
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
-    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, (response)=>{
-        this.hasShowed = false;
-        callback&&callback(response);
-    })
+    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, callback)
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const DEFAULT_OPTIONS = {
     title: 'Permission denied',
     text: 'To be able to take pictures with your camera and choose images from your library.',
     reTryTitle: 're-try',
+    settingTitle: 'Open Settins',
     okTitle: 'I\'m sure',
   }
 };

--- a/index.js
+++ b/index.js
@@ -22,10 +22,17 @@ const DEFAULT_OPTIONS = {
 module.exports = {
   ...ImagePickerManager,
   showImagePicker: function showImagePicker(options, callback) {
+    if(this.hasShow){
+      return;
+    }
+    this.hasShow = true;
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
-    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, callback)
+    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, (response)=>{
+      this.hasShow = false;
+      callback&&callback(response);
+    })
   }
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

iOS only. (Android has supported this festure, so this is iOS version. 

When the permission is denied at the first time, we cannot use this library until  we enable the permission in system settings. 

This PR provides a simple way to solve it by showing a alert view when the permission is denied, and user can click 'Open Setting'(default title) to open the app's settings directly.

All title in alert view can be customized. I have update the README.

You can disable this feature by make `permissionDenied` be null. (Only for iOS)

## Test Plan (required)

First, you should deny the permission at first time, also you can disable the permission in system settings if you have enabled it sometime.

Then click 'Take Photo…', the 'permission denied' alert view will show with two button('I'm sure' and 'Open Settings'). You can click 'Open Settings' if you want enable permission, or click 'I'm sure' nothing will happen.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
