### PR TITLE
Android to pick from document picker instead of camera library

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-* Fixedse read the following carefully before opening a new issue.
+* Please read the following carefully before opening a new issue.
 Your issue may be closed if it does not provide the information required by this template.
 
 --- Delete everything above this line ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# React Native Image Picker [![npm version](https://badge.fury.io/js/react-native-image-picker.svg)](https://badge.fury.io/js/react-native-image-picker) [![npm](https://img.shields.io/npm/dt/react-native-image-picker.svg)](https://www.npmjs.org/package/react-native-image-picker) ![MIT](https://img.shields.io/dub/l/vibe-d.svg) ![Platform - Android and iOS](https://img.shields.io/badge/platform-Android%20%7C%20iOS-yellow.svg)
+# React Native Image Picker [![npm version](https://badge.fury.io/js/react-native-image-picker.svg)](https://badge.fury.io/js/react-native-image-picker) [![npm](https://img.shields.io/npm/dt/react-native-image-picker.svg)](https://www.npmjs.org/package/react-native-image-picker) ![MIT](https://img.shields.io/dub/l/vibe-d.svg) ![Platform - Android and iOS](https://img.shields.io/badge/platform-Android%20%7C%20iOS-yellow.svg) [![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/react-native-image-picker/Lobby)
 
 A React Native module that allows you to use native UI to select a photo/video from the device library or directly from the camera, like so:
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -306,14 +306,21 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     if (pickVideo)
     {
       requestCode = REQUEST_LAUNCH_VIDEO_LIBRARY;
-      libraryIntent = new Intent(Intent.ACTION_PICK);
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+        libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+      } else {
+        libraryIntent = new Intent(Intent.ACTION_PICK);
+      }
       libraryIntent.setType("video/*");
     }
     else
     {
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
-      libraryIntent = new Intent(Intent.ACTION_PICK,
-      MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+        libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+      } else {
+        libraryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+      }
     }
 
     if (libraryIntent.resolveActivity(reactContext.getPackageManager()) == null)

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -280,6 +280,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       requestCode = REQUEST_LAUNCH_VIDEO_LIBRARY;
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
         libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
       } else {
         libraryIntent = new Intent(Intent.ACTION_PICK);
       }
@@ -289,6 +290,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       requestCode = REQUEST_LAUNCH_VIDEO_LIBRARY;
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
         libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
       } else {
         libraryIntent = new Intent(Intent.ACTION_PICK);
       }
@@ -299,6 +301,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
         libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
       } else {
         libraryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
       }

--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -31,7 +31,7 @@ public class ImagePickerPackage implements ReactPackage {
     return Arrays.<NativeModule>asList(new ImagePickerModule(reactContext, dialogThemeId));
   }
 
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -31,7 +31,6 @@ public class ImagePickerPackage implements ReactPackage {
     return Arrays.<NativeModule>asList(new ImagePickerModule(reactContext, dialogThemeId));
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -75,6 +75,13 @@ public class RealPathUtil {
 			else if (isDownloadsDocument(uri)) {
 
 				final String id = DocumentsContract.getDocumentId(uri);
+
+				// Handle raw file urls differently, we can just return the current string minus
+				// the raw: prefix. https://github.com/Yalantis/uCrop/issues/318
+				if (id != null && id.startsWith("raw:")) {
+					return id.substring(4);
+				}
+
 				final Uri contentUri = ContentUris.withAppendedId(
 						Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 				try {

--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -13,8 +13,20 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.FileProvider;
+import android.util.Log;
+import android.provider.OpenableColumns;
 
 import java.io.File;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.DecimalFormat;
+import java.util.Comparator;
 
 public class RealPathUtil {
 
@@ -43,6 +55,8 @@ public class RealPathUtil {
 
 		final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
+		final String Tag = "PadletRealPathUtil";
+
 		// DocumentProvider
 		if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
 			// ExternalStorageProvider
@@ -63,8 +77,35 @@ public class RealPathUtil {
 				final String id = DocumentsContract.getDocumentId(uri);
 				final Uri contentUri = ContentUris.withAppendedId(
 						Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+				try {
+					return getDataColumn(context, contentUri, null, null);
+				}
+				catch(Exception e) {
+					e.printStackTrace();
+				}
 
-				return getDataColumn(context, contentUri, null, null);
+				// File couldn't be loaded so we have to create a temporary file and then stream
+				// the contents into that file, some of this code has been implemented from
+				// https://github.com/coltoscosmin/FileUtils/blob/master/FileUtils.java 
+				
+				String fileName = getFileName(context, uri);
+				File cacheDir = new File(context.getCacheDir(), "documents");
+				if (!cacheDir.exists()) cacheDir.mkdirs();
+				File file = new File(cacheDir, fileName);
+				try {
+					file.createNewFile();
+				}
+				catch(Exception e) {
+					e.printStackTrace();
+				}
+				String destinationPath = file.getAbsolutePath();
+				Log.d(Tag, "Destination path: " + destinationPath);
+				if (file != null) {
+					destinationPath = file.getAbsolutePath();
+					saveFileFromUri(context, uri, destinationPath);
+				}
+
+				return destinationPath;
 			}
 			// MediaProvider
 			else if (isMediaDocument(uri)) {
@@ -198,5 +239,68 @@ public class RealPathUtil {
 		final File appDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
 		final File file = new File(appDir, uri.getLastPathSegment());
 		return file.exists() ? file.toString(): null;
+	}
+
+	private static void saveFileFromUri(Context context, Uri uri, String destinationPath) {
+		InputStream is = null;
+		BufferedOutputStream bos = null;
+		try {
+			is = context.getContentResolver().openInputStream(uri);
+			bos = new BufferedOutputStream(new FileOutputStream(destinationPath, false));
+			byte[] buf = new byte[1024];
+			is.read(buf);
+			do {
+				bos.write(buf);
+			} while (is.read(buf) != -1);
+		} catch (IOException e) {
+			e.printStackTrace();
+		} finally {
+			try {
+				if (is != null) is.close();
+				if (bos != null) bos.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public static String getFileName(@NonNull Context context, Uri uri) {
+		String mimeType = context.getContentResolver().getType(uri);
+		String filename = null;
+
+		if (mimeType == null && context != null) {
+			String path = getPath(context, uri);
+			if (path == null) {
+				filename = getName(uri.toString());
+			} else {
+				File file = new File(path);
+				filename = file.getName();
+			}
+		} else {
+			Cursor returnCursor = context.getContentResolver().query(uri, null,
+					null, null, null);
+			if (returnCursor != null) {
+				int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+				returnCursor.moveToFirst();
+				filename = returnCursor.getString(nameIndex);
+				returnCursor.close();
+			}
+		}
+
+		return filename;
+	}
+
+	public static String getName(String filename) {
+		if (filename == null) {
+			return null;
+		}
+		int index = filename.lastIndexOf('/');
+		return filename.substring(index + 1);
+	}
+
+	public static String getPath(final Context context, final Uri uri) {
+		String absolutePath = getRealPathFromURI(context, uri);
+		// String absolutePath = getLocalPath(context, uri);
+		return absolutePath != null ? absolutePath : uri.toString();
 	}
 }

--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -69,7 +69,7 @@ public class RealPathUtil {
 
 				final String id = DocumentsContract.getDocumentId(uri);
 
-				if (id != null)
+				if (id != null) {
 					// Handle raw file urls differently, we can just return the current string minus
 					// the raw: prefix. https://github.com/Yalantis/uCrop/issues/318
 					if (id.startsWith("raw:")) {

--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -117,13 +117,6 @@ public class RealPathUtil {
 			// MediaProvider
 			else if (isMediaDocument(uri)) {
 				final String docId = DocumentsContract.getDocumentId(uri);
-
-				// Handle raw file urls differently, we can just return the current string minus
-				// the raw: prefix. https://github.com/Yalantis/uCrop/issues/318
-				if (id != null && id.startsWith("raw:")) {
-					return id.substring(4);
-				}
-
 				final String[] split = docId.split(":");
 				final String type = split[0];
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.27.0",
+  "version": "1.0.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "picker"
   ],
   "scripts": {
-    "prepublish": "rm -rf android/build Example/android/build Example/android/app/build node_modules"
+    "prepare": "rm -rf android/build Example/android/build Example/android/app/build node_modules"
   },
   "types": "./index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?
Image picker only picks from camera library using ACTION_PICK intent. We change to ACTION_OPEN_DOCUMENT to pick photos and videos in other phone directories.

## Test Plan (required)

1. Use 
```
ImagePicker.launchImageLibrary(options, async (data) => {
        console.log(data);
});
```

2. A document library picker should open instead of camera image picker
