### PR TITLE
add 'showImageChooser' method (only for Android)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { NativeModules } = require('react-native');
+const { NativeModules, Platform } = require('react-native');
 const { ImagePickerManager } = NativeModules;
 
 const DEFAULT_OPTIONS = {
@@ -26,5 +26,16 @@ module.exports = {
       options = {};
     }
     return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, callback)
-  }
+  },
+  showImageChooser: function showImageChooser(options, callback) {
+	if (Platform.OS !== 'android') {
+	  console.warn('showImageChooser is available only on Android');
+	  return;
+	}
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    return ImagePickerManager.showImageChooser({...DEFAULT_OPTIONS, ...options}, callback)
+  } 
 }


### PR DESCRIPTION
## Motivation (required)

Currently if you want to let the user decide if to take a photo or to select from gallery, you should use the 'showImagePicker' method, that will show a dialog with the two options. After selecting the right option, the user chooses again which app to use. It's a 2 step process.

In order to make the process smoother and simpler, this PR adds a 'showImageChooser' method that proposes immediately to the user the apps that he can use in order to pick the image, either from camera or from gallery. Every app on the phone that can take a photo or grab it from gallery will be listed.

## Test Plan (required)

Tested on real device (Android 7.0)

![screenshot_20170908-151451](https://user-images.githubusercontent.com/3854477/30213878-c48bdf70-94aa-11e7-96bc-cd03eaaa8874.jpg)

If the user chooses the gallery app, the pic is taken correctly.
If the user chooses the camera app, the pic is taken correctly.
If the user chooses the document app and selects a wrong file (not an image), the promise is rejected with an error.



