### PR TITLE
fix android saving to gallery AND temp & ios video more unique name

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ durationLimit | OK | OK | Max video recording time, in seconds
 rotation | - | OK | Photos only, 0 to 360 degrees of rotation
 allowsEditing | OK | - | bool - enables built in iOS functionality to resize the image after selection
 noData | OK | OK | If true, disables the base64 `data` field from being generated (greatly improves performance on large photos)
+noGallery | - | OK | If true, image or video will be stored only in the temporary directory on Android and will NOT be in your gallery
 storageOptions | OK | OK | If this key is provided, the image will be saved in your app's `Documents` directory on iOS, or your app's `Pictures` directory on Android (rather than a temporary directory)
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`
@@ -260,7 +261,7 @@ width | OK | OK | Image dimensions
 height | OK | OK | Image dimensions
 fileSize | OK | OK | The file size (photos only)
 type | - | OK | The file type (photos only)
-fileName | OK (photos and videos) | OK (photos) | The file name
+fileName | OK | OK | The file name
 path | - | OK | The file path
 latitude | OK | OK | Latitude metadata, if available
 longitude | OK | OK | Longitude metadata, if available

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ durationLimit | OK | OK | Max video recording time, in seconds
 rotation | - | OK | Photos only, 0 to 360 degrees of rotation
 allowsEditing | OK | - | bool - enables built in iOS functionality to resize the image after selection
 noData | OK | OK | If true, disables the base64 `data` field from being generated (greatly improves performance on large photos)
-noGallery | - | OK | If true, image or video will be stored only in the temporary directory on Android and will NOT be in your gallery
+noGallery | - | OK | If true, image or video will be stored only in the temporary directory on Android and will NOT be in the gallery
 storageOptions | OK | OK | If this key is provided, the image will be saved in your app's `Documents` directory on iOS, or your app's `Pictures` directory on Android (rather than a temporary directory)
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.+'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     compile "com.facebook.react:react-native:+"  // From node_modules
-    
+
     testCompile "junit:junit:4.10"
     testCompile "org.assertj:assertj-core:1.7.0"
     testCompile "org.robolectric:robolectric:3.3.2"

--- a/android/src/main/java/com/imagepicker/media/LastFile.java
+++ b/android/src/main/java/com/imagepicker/media/LastFile.java
@@ -1,0 +1,65 @@
+package com.imagepicker.media;
+
+import java.io.File;
+
+/**
+ * Author: Chandler Newman-Reed
+ * Project: imagepicker
+ * Date: 9/19/2017
+ * Purpose: Created to help fix the issue with putExtra (on different devices) when taking
+ *          images or videos with ACTION_CAPTURE.
+ */
+
+public class LastFile {
+    private long size;
+    private int id;
+    private String path;
+
+    public LastFile(){
+        size = 0;
+        id = -1;
+    }
+
+    public LastFile(int id, long size, String path){
+        this.size = size;
+        this.id = id;
+        this.path = path;
+    }
+
+    public long getSize(){
+        return size;
+    }
+
+    public int getId(){
+        return id;
+    }
+
+    public String getPath(){
+        return path;
+    }
+
+    public File getFile(){
+        return new File(path);
+    }
+
+    /*
+     * Not exactly used but is there just incase
+     */
+    public boolean equals(LastFile lastFile){
+        if(this.size == lastFile.getSize() && this.id == lastFile.getId()){
+            return true;
+        }
+        return false;
+    }
+
+    /*
+     * If last image id in the media store is greater than the id of the new image than we
+     * can assume that the image is a new image
+     */
+    public boolean notLastFile(LastFile lastFile){
+        if(this.id > lastFile.getId()){
+            return true;
+        }
+        return false;
+    }
+}

--- a/android/src/main/java/com/imagepicker/media/VideoConfig.java
+++ b/android/src/main/java/com/imagepicker/media/VideoConfig.java
@@ -1,9 +1,32 @@
 package com.imagepicker.media;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.bridge.ReadableMap;
+
+import java.io.File;
+
 /**
  * Created by rusfearuth on 16.03.17.
  */
 
 public class VideoConfig
 {
+    public @Nullable final File original;
+
+    public VideoConfig(@Nullable final File original)
+    {
+        this.original = original;
+    }
+
+    public @NonNull VideoConfig withOriginalFile(@Nullable final File original)
+    {
+        return new VideoConfig(original);
+    }
+
+    public File getActualFile()
+    {
+        return original;
+    }
 }

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -66,6 +66,30 @@ public class MediaUtils
         return result;
     }
 
+    public static @Nullable File createNewVideoFile(@NonNull final Context reactContext){
+
+        final String filename = new StringBuilder("video-")
+                .append(UUID.randomUUID().toString())
+                .append(".mp4")
+                .toString();
+
+        final File path = reactContext.getExternalCacheDir();
+
+        File result = new File(path, filename);
+
+        try
+        {
+            path.mkdirs();
+            result.createNewFile();
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+            result = null;
+        }
+
+        return result;
+    }
     /**
      * Create a resized image to fulfill the maxWidth/maxHeight, quality and rotation values
      *

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -450,7 +450,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
                 if (videoURL) { // Protect against reported crash
                   NSError *error = nil;
-                  [fileManager moveItemAtURL:videoURL toURL:videoDestinationURL error:&error];
+                  [fileManager copyItemAtURL:videoURL toURL:videoDestinationURL error:&error];
                   if (error) {
                       self.callback(@[@{@"error": error.localizedFailureReason}]);
                       return;

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -252,8 +252,8 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             }
         }
         else {
-            NSURL *videoURL = info[UIImagePickerControllerMediaURL];
-            fileName = videoURL.lastPathComponent;
+            NSString *dateTime = [[ImagePickerManager VideoFilenameFormat] stringFromDate:[NSDate date]];
+            fileName = [dateTime stringByAppendingString:@".mov"];
         }
 
         // We default to path to the temporary directory
@@ -699,6 +699,19 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         ISO8601DateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZZZZZ";
     });
     return ISO8601DateFormatter;
+}
+
++ (NSDateFormatter * _Nonnull)VideoFilenameFormat {
+    static NSDateFormatter *VideoFilenameFormat;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        VideoFilenameFormat = [[NSDateFormatter alloc] init];
+        NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        VideoFilenameFormat.locale = enUSPOSIXLocale;
+        VideoFilenameFormat.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        VideoFilenameFormat.dateFormat = @"'VIDEO_'yyyyMMddHHmmssSS";
+    });
+    return VideoFilenameFormat;
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-native-image-picker",
-  "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.7",
+  "name": "react-native-image-picker-m",
+  "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera (modified from original)",
+  "version": "0.26.8",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/marcshilling/react-native-image-picker.git"
+    "url": "https://github.com/chan3111/react-native-image-picker.git"
   },
   "nativePackage": true,
   "author": "Marc Shilling (marcshilling)",
@@ -21,7 +21,11 @@
     {
       "name": "Alexander Ustinov",
       "email": "rusfearuth@gmail.com"
-    }
+    },
+	{
+	   "name": "Chandler Newman-Reed",
+	   "email": "chandlernewmanreed@gmail.com"
+	}
   ],
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker-m",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera (modified from original)",
-  "version": "0.26.8",
+  "version": "0.27.0",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Motivation (required)

For my company we are moving to react native and using this plugin to be able to capture images and videos. It is important that the image or video isn't saved to the gallery at all. The plugin works for that by not defining 'storageOptions' on IOS but for some devices on Android I found that it wouldn't always work. There is an issue with using putExtra on some devices. Essentially there are three different scenarios: 1. Camera only saves with the directory you define and pass through putExtra and doesn't save elsewhere. 2. Camera saves with the defined directory putExtra but also saves to the gallery at a seperate location. 3. Camera saves to ONLY the gallery location and ignores putExtra. I implemented a way to work around this issue and added an option for both video and picture 'noGallery' to ensure that if true the picture or video won't be saved to the gallery.

The second this I did was just finished the videoConfig (not necessary but nice to have) and sort of copied the way the images are taken for videos. So now the videos will return a fileName in the response object making it easier than having to use splice with the path to get it.

The third thing was just a simple change to the saved filename for IOS so that in a situation where you are uploading one video after the other and they are being displayed by filename, the name is unique and can be used as a key or atleast differentiated. It now uses the date and time with VIDEO_ prepended.

## Test Plan (required)

I tested this on three seperate Android devices, an old LG K4 (had saving gallery issue), a galaxy tablet and a Moto E (2nd Gen) (also had saving gallery issue) for the android changes.  I tested the IOS change on an IPad Mini (ios 9.3.x) and an IPhone 6 (ios 10.3.x). The only thing that I wasn't able to test was the third scenario of the putExtra situation. I only read that this issue happens but am not sure which devices do this, there is an implementation for it but I have no way of testing it. If anyone knows of such device or can test it for me, that would be greatly appreciated.
