### PR TITLE
fix android camera for some phones

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -365,7 +365,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     responseHelper.cleanResponse();
 
     // user cancel
-    if (resultCode != Activity.RESULT_OK)
+    if (requestCode != REQUEST_LAUNCH_IMAGE_CAPTURE && resultCode != Activity.RESULT_OK)
     {
       removeUselessFiles(requestCode, imageConfig);
       responseHelper.invokeCancel(callback);
@@ -436,6 +436,15 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     BitmapFactory.Options options = new BitmapFactory.Options();
     options.inJustDecodeBounds = true;
     BitmapFactory.decodeFile(imageConfig.original.getAbsolutePath(), options);
+
+    if (options.outMimeType == null || options.outWidth < 1)
+    {
+      removeUselessFiles(requestCode, imageConfig);
+      responseHelper.invokeCancel(callback);
+      callback = null;
+      return;
+    }
+
     int initialWidth = options.outWidth;
     int initialHeight = options.outHeight;
     updatedResultResponse(uri, imageConfig.original.getAbsolutePath());


### PR DESCRIPTION
Invoking the camera to take a photo would always return `didCancel=true`, even when actually taking a photo on my LG G3 (D855) under Android 7.1.1.

In `onActivityResult`, my camera app (`org.cyanogenmod.snap`) always returns a `resultCode` of `Activity.RESULT_CANCELED` instead of `Activity.RESULT_OK`.

This improves/fixes https://github.com/react-community/react-native-image-picker/pull/506