### PR TITLE
Add flags to grant permissions to access Uri into the intent.

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -275,16 +275,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
     this.callback = callback;
 
-    // Workaround for Android bug.
-    // grantUriPermission also needed for KITKAT,
-    // see https://code.google.com/p/android/issues/detail?id=76683
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-      List<ResolveInfo> resInfoList = reactContext.getPackageManager().queryIntentActivities(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY);
-      for (ResolveInfo resolveInfo : resInfoList) {
-        String packageName = resolveInfo.activityInfo.packageName;
-        reactContext.grantUriPermission(packageName, cameraCaptureURI, Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-      }
-    }
+    // Grant permission to access cameraCaptureURI
+    cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
     try
     {


### PR DESCRIPTION
Usage of Context.grantUriPermission should be followed by Contex.revokeUriPermission call when the target should no longer be allowed to access the Uri. 
It is advised by android documentation to grant permissions with Intent being used to start an activity instead of grantUriPermission function directly.