### PR TITLE
Fix the fact that the library asks for both permissions (camera and external storage) on Android

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -545,12 +545,39 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     final int cameraPermission = ActivityCompat
             .checkSelfPermission(activity, Manifest.permission.CAMERA);
 
-    final boolean permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED &&
-            cameraPermission == PackageManager.PERMISSION_GRANTED;
+    final boolean permissionsGrated;
+
+    switch (requestCode)
+    {
+      case REQUEST_PERMISSIONS_FOR_CAMERA:
+        permissionsGrated = cameraPermission == PackageManager.PERMISSION_GRANTED;
+        break;
+
+      case REQUEST_PERMISSIONS_FOR_LIBRARY:
+        permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED;
+        break;
+
+      default:
+        permissionsGrated = cameraPermission == PackageManager.PERMISSION_GRANTED && writePermission == PackageManager.PERMISSION_GRANTED;
+    }
 
     if (!permissionsGrated)
     {
-      final Boolean dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA);
+      final Boolean dontAskAgain;
+
+      switch (requestCode)
+      {
+        case REQUEST_PERMISSIONS_FOR_CAMERA:
+          dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA);
+          break;
+
+        case REQUEST_PERMISSIONS_FOR_LIBRARY:
+          dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+          break;
+
+        default:
+          dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA) && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+      }
 
       if (dontAskAgain)
       {
@@ -597,6 +624,17 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       else
       {
         String[] PERMISSIONS = {Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA};
+        switch (requestCode)
+        {
+          case REQUEST_PERMISSIONS_FOR_CAMERA:
+            PERMISSIONS = new String[]{Manifest.permission.CAMERA};
+            break;
+
+          case REQUEST_PERMISSIONS_FOR_LIBRARY:
+            PERMISSIONS = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
+            break;
+        }
+
         if (activity instanceof ReactActivity)
         {
           ((ReactActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);


### PR DESCRIPTION
The library now in Android asks for both permissions ( camera and external storage ) in the same time when wanting to access gallery for example.
This behaviour is impacting the quality of the user experience .


## Motivation (required)
solving those issues : 
https://github.com/react-community/react-native-image-picker/issues/717
https://github.com/react-community/react-native-image-picker/issues/752
https://github.com/react-community/react-native-image-picker/issues/753

## Test Plan (required)

