### PR TITLE
Fix video in image edge case

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -455,7 +455,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       
       // some devices allow video anyways in photo only mode e.g Huawei Mate 20 Lite
       if (imageConfig == null) {
-        responseHelper.invokeError(callback, "Video is not supported in image mode");
+        responseHelper.putString("error", "Video is not supported in image mode");
         return;
       }
       
@@ -476,7 +476,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       }
     }
 
-    if (imageConfig.saveToCameraRoll && requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE)
+    if (imageConfig != null && imageConfig.saveToCameraRoll && requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE)
     {
       final RolloutPhotoResult rolloutResult = rolloutPhotoFromCamera(imageConfig);
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?
Some devices allow video anyways in photo only mode e.g Huawei Mate 20 Lite. This causes the app to crash on this line.
```
Fatal Exception: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=13002, result=-1, data=Intent { dat=content://media/external/video/media/179 flg=0x1 }} to activity {com.velocity.v4b.blme.staging/com.velocityapp.consumer.MainActivity}: java.lang.NullPointerException: Attempt to read from field 'java.io.File com.imagepicker.media.ImageConfig.resized' on a null object reference
       at android.app.ActivityThread.deliverResults(ActivityThread.java:5042)
       at android.app.ActivityThread.handleSendResult(ActivityThread.java:5086)
       at android.app.ActivityThread.-wrap20(Unknown Source)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2071)
       at android.os.Handler.dispatchMessage(Handler.java:109)
       at android.os.Looper.loop(Looper.java:166)
       at android.app.ActivityThread.main(ActivityThread.java:7555)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:469)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:963)
```

Instead, it should error appropriately. 

## Test Plan (required)
Use an android device at allows video and photo when specifying only photos in the intent. There are no type tests to really implement here; perhaps there's a bigger issue with the intent being sent, but I'm not a 'pro' Android dev or anything.  
