### PR TITLE
<Fix>fileName is null if photo from camera

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -307,6 +307,9 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
                 if (pickedAsset.creationDate) {
                     self.response[@"timestamp"] = [[ImagePickerManager ISO8601DateFormatter] stringFromDate:pickedAsset.creationDate];
                 }
+            }else if(self.picker.sourceType == UIImagePickerControllerSourceTypeCamera){
+                // If image from camera,`imageURL` will be nil
+                self.response[@"fileName"] = fileName;
             }
 
             // GIFs break when resized, so we handle them differently


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The `fileName` in response is nil  if photo from camera.
Fixed it.

## Test Plan (required)

take a photo by device and response have key of `fileName` 
