### PR TITLE
Fixed orientation on save in library

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -406,7 +406,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             if (storageOptions && [[storageOptions objectForKey:@"cameraRoll"] boolValue] == YES && self.picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
                 ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
                 if ([[storageOptions objectForKey:@"waitUntilSaved"] boolValue]) {
-                    [library writeImageToSavedPhotosAlbum:originalImage.CGImage metadata:[info valueForKey:UIImagePickerControllerMediaMetadata] completionBlock:^(NSURL *assetURL, NSError *error) {
+                    [library writeImageToSavedPhotosAlbum:originalImage.CGImage orientation:(ALAssetOrientation)[originalImage imageOrientation] completionBlock:^(NSURL *assetURL, NSError *error) {
                         if (error) {
                             NSLog(@"Error while saving picture into photo album");
                         } else {

--- a/react-native-image-picker.podspec
+++ b/react-native-image-picker.podspec
@@ -7,12 +7,12 @@ Pod::Spec.new do |s|
   s.version      = package['version']
   s.summary      = package['description']
 
-  s.authors      = { 'Marc Shilling' => 'marcshilling@gmail.com' }
+  s.authors      = { 'Clément Bock' => 'clement@zap.lu' }
   s.homepage     = package['homepage']
   s.license      = package['license']
   s.platform     = :ios, "7.0"
 
-  s.source       = { :git => "https://github.com/marcshilling/react-native-image-picker" }
+  s.source       = { :git => "https://github.com/zapsa/react-native-image-picker" }
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
Pictures taken by the camera were incorrectly saved in the iOS device library, they were rotated of 90° for the portrait ones and 180° for the landscape ones.

Tested on iPhone 6S and iPhone XS Max and iOS 11 and 12, works perfectly fine.