### PR TITLE
Fixed additional Permissions Issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     api "com.facebook.react:react-native:+"  // From node_modules
-    compile "com.droidninja:filepicker:2.2.1"
+    implementation "com.droidninja:filepicker:2.2.1"
 
     testImplementation "junit:junit:4.10"
     testImplementation "org.assertj:assertj-core:1.7.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,7 @@ repositories {
 
 dependencies {
     api "com.facebook.react:react-native:+"  // From node_modules
+    compile "com.droidninja:filepicker:2.2.1"
 
     testImplementation "junit:junit:4.10"
     testImplementation "org.assertj:assertj-core:1.7.0"

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -570,9 +570,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     final int cameraPermission = ActivityCompat
             .checkSelfPermission(activity, Manifest.permission.CAMERA);
 
-    final boolean permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED &&
-            cameraPermission == PackageManager.PERMISSION_GRANTED;
-            
     final boolean permissionsGrated;
     if (requestCode == REQUEST_PERMISSIONS_FOR_LIBRARY) {
       permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED;

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -572,6 +572,15 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
     final boolean permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED &&
             cameraPermission == PackageManager.PERMISSION_GRANTED;
+            
+    final boolean permissionsGrated;
+    if (requestCode == REQUEST_PERMISSIONS_FOR_LIBRARY) {
+      permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED;
+    } else {
+      permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED 
+                && cameraPermission == PackageManager.PERMISSION_GRANTED;
+    }
+          
 
     if (!permissionsGrated)
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,28 @@ class ImagePicker {
       callback,
     );
   }
+
+  launchDocumentLibrary(options: ImagePickerOptions, callback: Callback): void {
+    return NativeInterface.launchDocumentLibrary(
+      {
+        ...DEFAULT_OPTIONS,
+        ...options,
+        tintColor: processColor(options.tintColor || DEFAULT_OPTIONS.tintColor),
+      },
+      callback,
+    );
+  }  
+
+  launchFileBrowser(options: ImagePickerOptions, callback: Callback): void {
+    return NativeInterface.launchFileBrowser(
+      {
+        ...DEFAULT_OPTIONS,
+        ...options,
+        tintColor: processColor(options.tintColor || DEFAULT_OPTIONS.tintColor),
+      },
+      callback,
+    );
+  }    
 }
 
 export default new ImagePicker();


### PR DESCRIPTION
- [ ] Explain the **motivation** for making this change.
We need to take only the required permissions from the user. For Accessing photo library we need only the Storage permissions. But in current code we are requesting for camera permissions also. In current pull request we have modified code to request only storage permission for the photo library and removed camera permission

- [ ] Provide a **test plan** demonstrating that the code is solid.
Verified the photo library access with only storage permissions in android and it is working fine

- [ ] Match the **code formatting** of the rest of the codebase.
Yes

- [ ] Target the `master` branch, NOT a "stable" branch.
yes
