### PR TITLE
Removed unnecessary permission request on Android

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -565,15 +565,24 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                                    @NonNull final Callback callback,
                                    @NonNull final int requestCode)
   {
-    final int writePermission = ActivityCompat
+    int selfCheckResult = 0;
+    switch (requestCode)
+      {
+        case REQUEST_PERMISSIONS_FOR_CAMERA:
+          selfCheckResult = ActivityCompat
             .checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-    final int cameraPermission = ActivityCompat
+          break;
+
+        case REQUEST_PERMISSIONS_FOR_LIBRARY:
+          selfCheckResult = ActivityCompat
             .checkSelfPermission(activity, Manifest.permission.CAMERA);
+          break;
 
-    final boolean permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED &&
-            cameraPermission == PackageManager.PERMISSION_GRANTED;
+      }
 
-    if (!permissionsGrated)
+    final boolean permissionsGranted = selfCheckResult == PackageManager.PERMISSION_GRANTED;
+
+    if (!permissionsGranted)
     {
       final Boolean dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA);
 
@@ -621,7 +630,12 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       }
       else
       {
-        String[] PERMISSIONS = {Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA};
+        String[] PERMISSIONS = {Manifest.permission.CAMERA};
+        if (requestCode == REQUEST_PERMISSIONS_FOR_LIBRARY )
+        {
+            PERMISSIONS[0] = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+        }
+
         if (activity instanceof ReactActivity)
         {
           ((ReactActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);
@@ -644,7 +658,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                   .toString();
           throw new UnsupportedOperationException(errorDescription);
         }
-        return false;
       }
     }
     return true;

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -12,11 +12,11 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.provider.Settings;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StyleRes;
-import androidx.core.app.ActivityCompat;
-import androidx.appcompat.app.AlertDialog;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StyleRes;
+import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Patterns;
@@ -30,13 +30,12 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.module.annotations.ReactModule;
 import com.imagepicker.media.ImageConfig;
 import com.imagepicker.permissions.PermissionUtils;
 import com.imagepicker.permissions.OnImagePickerPermissionsCallback;
 import com.imagepicker.utils.MediaUtils.ReadExifResult;
-import com.imagepicker.utils.ReadableMapUtils;
 import com.imagepicker.utils.RealPathUtil;
+import com.imagepicker.utils.ReadableMapUtils;
 import com.imagepicker.utils.UI;
 
 import java.io.ByteArrayOutputStream;
@@ -57,13 +56,9 @@ import static com.imagepicker.utils.MediaUtils.*;
 import static com.imagepicker.utils.MediaUtils.createNewFile;
 import static com.imagepicker.utils.MediaUtils.getResizedImage;
 
-@ReactModule(name = ImagePickerModule.NAME)
 public class ImagePickerModule extends ReactContextBaseJavaModule
         implements ActivityEventListener
 {
-  public static final String NAME = "ImagePickerManager";
-
-  public static final int DEFAULT_EXPLAINING_PERMISSION_DIALIOG_THEME = R.style.DefaultExplainingPermissionsTheme;
 
   public static final int REQUEST_LAUNCH_IMAGE_CAPTURE    = 13001;
   public static final int REQUEST_LAUNCH_IMAGE_LIBRARY    = 13002;
@@ -80,7 +75,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   protected Uri cameraCaptureURI;
   private Boolean noData = false;
   private Boolean pickVideo = false;
-  private Boolean pickBoth = false;
   private ImageConfig imageConfig = new ImageConfig(null, null, 0, 0, 100, 0, false);
 
   @Deprecated
@@ -99,8 +93,11 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       boolean permissionsGranted = true;
       for (int i = 0; i < permissions.length; i++)
       {
-        final boolean granted = grantResults[i] == PackageManager.PERMISSION_GRANTED;
-        permissionsGranted = permissionsGranted && granted;
+        // String[2] arr[0] == "" arr[1] == null
+        if (permissions[i] != null) {
+          final boolean granted = grantResults[i] == PackageManager.PERMISSION_GRANTED;
+          permissionsGranted = permissionsGranted && granted;
+        }
       }
 
       if (callback == null || options == null)
@@ -129,11 +126,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     }
   };
 
-  public ImagePickerModule(ReactApplicationContext reactContext)
-  {
-    this(reactContext, DEFAULT_EXPLAINING_PERMISSION_DIALIOG_THEME);
-  }
-
   public ImagePickerModule(ReactApplicationContext reactContext,
                            @StyleRes final int dialogThemeId)
   {
@@ -146,7 +138,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   @Override
   public String getName() {
-    return NAME;
+    return "ImagePickerManager";
   }
 
   @ReactMethod
@@ -267,7 +259,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
       cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
 
-      final File original = createNewFile(reactContext, this.options, false);
+      boolean shouldForceLocal = !(ReadableMapUtils.hasAndNotNullReadableMap(this.options, "storageOptions") && ReadableMapUtils.hasAndNotEmptyString(this.options.getMap("storageOptions"), "path"));
+      final File original = createNewFile(reactContext, this.options, shouldForceLocal);
       imageConfig = imageConfig.withOriginalFile(original);
 
       if (imageConfig.original != null) {
@@ -349,11 +342,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
       libraryIntent = new Intent(Intent.ACTION_PICK,
       MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-
-      if (pickBoth) 
-      {
-        libraryIntent.setType("image/* video/*");
-      }
     }
 
     if (libraryIntent.resolveActivity(reactContext.getPackageManager()) == null)
@@ -364,13 +352,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
     try
     {
-      String chooseWhichLibraryTitle = null;
-      if (ReadableMapUtils.hasAndNotEmptyString(options, "chooseWhichLibraryTitle"))
-      {
-        chooseWhichLibraryTitle = options.getString("chooseWhichLibraryTitle");
-      }
-
-      currentActivity.startActivityForResult(Intent.createChooser(libraryIntent, chooseWhichLibraryTitle), requestCode);
+      currentActivity.startActivityForResult(libraryIntent, requestCode);
     }
     catch (ActivityNotFoundException e)
     {
@@ -570,12 +552,17 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       {
         case REQUEST_PERMISSIONS_FOR_CAMERA:
           selfCheckResult = ActivityCompat
-            .checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+            .checkSelfPermission(activity, Manifest.permission.CAMERA);
+          if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions") && ReadableMapUtils.hasAndNotEmptyString(options.getMap("storageOptions"), "path"))
+          {
+            selfCheckResult = ActivityCompat
+              .checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);  
+          }
           break;
 
         case REQUEST_PERMISSIONS_FOR_LIBRARY:
           selfCheckResult = ActivityCompat
-            .checkSelfPermission(activity, Manifest.permission.CAMERA);
+            .checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
           break;
 
       }
@@ -630,7 +617,16 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       }
       else
       {
-        String[] PERMISSIONS = {Manifest.permission.CAMERA};
+        String[] PERMISSIONS = new String[2];
+        if (requestCode == REQUEST_PERMISSIONS_FOR_CAMERA )
+        {
+            PERMISSIONS[0] = Manifest.permission.CAMERA;
+            if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")
+                && ReadableMapUtils.hasAndNotEmptyString(options.getMap("storageOptions"), "path")) 
+            {
+              PERMISSIONS[1] = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+            }
+        }
         if (requestCode == REQUEST_PERMISSIONS_FOR_LIBRARY )
         {
             PERMISSIONS[0] = Manifest.permission.WRITE_EXTERNAL_STORAGE;
@@ -658,6 +654,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                   .toString();
           throw new UnsupportedOperationException(errorDescription);
         }
+        return false;
       }
     }
     return true;
@@ -752,10 +749,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     }
     imageConfig = imageConfig.updateFromOptions(options);
     pickVideo = false;
-    pickBoth = false;
-    if (options.hasKey("mediaType") && options.getString("mediaType").equals("mixed")) {
-      pickBoth = true;
-    }
     if (options.hasKey("mediaType") && options.getString("mediaType").equals("video")) {
       pickVideo = true;
     }

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -12,11 +12,11 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.StyleRes;
-import android.support.v4.app.ActivityCompat;
-import android.support.v7.app.AlertDialog;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StyleRes;
+import androidx.core.app.ActivityCompat;
+import androidx.appcompat.app.AlertDialog;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Patterns;
@@ -30,12 +30,13 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.module.annotations.ReactModule;
 import com.imagepicker.media.ImageConfig;
 import com.imagepicker.permissions.PermissionUtils;
 import com.imagepicker.permissions.OnImagePickerPermissionsCallback;
 import com.imagepicker.utils.MediaUtils.ReadExifResult;
-import com.imagepicker.utils.RealPathUtil;
 import com.imagepicker.utils.ReadableMapUtils;
+import com.imagepicker.utils.RealPathUtil;
 import com.imagepicker.utils.UI;
 
 import java.io.ByteArrayOutputStream;
@@ -56,9 +57,13 @@ import static com.imagepicker.utils.MediaUtils.*;
 import static com.imagepicker.utils.MediaUtils.createNewFile;
 import static com.imagepicker.utils.MediaUtils.getResizedImage;
 
+@ReactModule(name = ImagePickerModule.NAME)
 public class ImagePickerModule extends ReactContextBaseJavaModule
         implements ActivityEventListener
 {
+  public static final String NAME = "ImagePickerManager";
+
+  public static final int DEFAULT_EXPLAINING_PERMISSION_DIALIOG_THEME = R.style.DefaultExplainingPermissionsTheme;
 
   public static final int REQUEST_LAUNCH_IMAGE_CAPTURE    = 13001;
   public static final int REQUEST_LAUNCH_IMAGE_LIBRARY    = 13002;
@@ -75,6 +80,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   protected Uri cameraCaptureURI;
   private Boolean noData = false;
   private Boolean pickVideo = false;
+  private Boolean pickBoth = false;
   private ImageConfig imageConfig = new ImageConfig(null, null, 0, 0, 100, 0, false);
 
   @Deprecated
@@ -93,7 +99,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       boolean permissionsGranted = true;
       for (int i = 0; i < permissions.length; i++)
       {
-        // String[2] arr[0] == "" arr[1] == null
         if (permissions[i] != null) {
           final boolean granted = grantResults[i] == PackageManager.PERMISSION_GRANTED;
           permissionsGranted = permissionsGranted && granted;
@@ -126,6 +131,11 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     }
   };
 
+  public ImagePickerModule(ReactApplicationContext reactContext)
+  {
+    this(reactContext, DEFAULT_EXPLAINING_PERMISSION_DIALIOG_THEME);
+  }
+
   public ImagePickerModule(ReactApplicationContext reactContext,
                            @StyleRes final int dialogThemeId)
   {
@@ -138,7 +148,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   @Override
   public String getName() {
-    return "ImagePickerManager";
+    return NAME;
   }
 
   @ReactMethod
@@ -342,6 +352,11 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
       libraryIntent = new Intent(Intent.ACTION_PICK,
       MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+
+      if (pickBoth) 
+      {
+        libraryIntent.setType("image/* video/*");
+      }
     }
 
     if (libraryIntent.resolveActivity(reactContext.getPackageManager()) == null)
@@ -352,7 +367,13 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
     try
     {
-      currentActivity.startActivityForResult(libraryIntent, requestCode);
+      String chooseWhichLibraryTitle = null;
+      if (ReadableMapUtils.hasAndNotEmptyString(options, "chooseWhichLibraryTitle"))
+      {
+        chooseWhichLibraryTitle = options.getString("chooseWhichLibraryTitle");
+      }
+
+      currentActivity.startActivityForResult(Intent.createChooser(libraryIntent, chooseWhichLibraryTitle), requestCode);
     }
     catch (ActivityNotFoundException e)
     {
@@ -749,6 +770,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     }
     imageConfig = imageConfig.updateFromOptions(options);
     pickVideo = false;
+    pickBoth = false;
+    if (options.hasKey("mediaType") && options.getString("mediaType").equals("mixed")) {
+      pickBoth = true;
+    }
     if (options.hasKey("mediaType") && options.getString("mediaType").equals("video")) {
       pickVideo = true;
     }

--- a/android/src/main/java/com/imagepicker/media/ImageConfig.java
+++ b/android/src/main/java/com/imagepicker/media/ImageConfig.java
@@ -1,7 +1,7 @@
 package com.imagepicker.media;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.webkit.MimeTypeMap;
 
 import com.facebook.react.bridge.ReadableMap;

--- a/android/src/main/java/com/imagepicker/media/ImageConfig.java
+++ b/android/src/main/java/com/imagepicker/media/ImageConfig.java
@@ -1,7 +1,7 @@
 package com.imagepicker.media;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.webkit.MimeTypeMap;
 
 import com.facebook.react.bridge.ReadableMap;

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -8,8 +8,8 @@ import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Environment;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -20,7 +20,6 @@ import com.imagepicker.media.ImageConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -8,8 +8,8 @@ import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Environment;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -20,6 +20,7 @@ import com.imagepicker.media.ImageConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -156,8 +157,9 @@ public class MediaUtils
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         scaledPhoto.compress(Bitmap.CompressFormat.JPEG, result.quality, bytes);
 
-        final boolean forceLocal = requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE;
-        final File resized = createNewFile(context, options, !forceLocal);
+        final boolean forceLocal = requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE && !(ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")
+                && ReadableMapUtils.hasAndNotEmptyString(options.getMap("storageOptions"), "path"));
+        final File resized = createNewFile(context, options, forceLocal);
 
         if (resized == null)
         {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)
Currently, on Android, the library requests permissions for both the external storage and the camera. 

This causes unexpected behavior as there could be times where a user would want to only allow permission for one and not the other.

Currently, the library is only saving to the external storage no matter what, so the `EXTERNAL_STORAGE` permission will still be needed, even if the user only wants to access the camera. To resolve this, I have updated the logic that writes to the external storage to only write there if the `storageOptions.path` property exists. This allows the library to save the capture imaged locally and avoids needing that extra permission unless explicitly asked for.

This PR updates the code base to match the expected behavior without using any additional external libraries

## Test Plan (required)

Ran on actual Android device (Samsung S9) and verified that the permission accept and declined behaviors are as expected:
Accept: Only ask for the one requested and opens the requested resource
Decline: Dismisses the permission alert

If you have added code that should be tested, add tests.
