### PR TITLE
BUGFIX Android crash fix when decoding unsupported files types

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -350,7 +350,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       libraryIntent = new Intent(Intent.ACTION_PICK,
       MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
 
-      if (pickBoth) 
+      if (pickBoth)
       {
         libraryIntent.setType("image/* video/*");
       }
@@ -474,7 +474,15 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     }
     else
     {
-      imageConfig = getResizedImage(reactContext, this.options, imageConfig, initialWidth, initialHeight, requestCode);
+      ImageConfig resizedImageConfig = getResizedImage(reactContext, this.options, imageConfig, initialWidth, initialHeight, requestCode);
+      if (resizedImageConfig == null) {
+        // probably an unsupported file type
+        removeUselessFiles(requestCode, imageConfig);
+        responseHelper.invokeError(callback, "Error resizing image. Check if the file type is supported on Android.");
+        callback = null;
+        return;
+      }
+      imageConfig = resizedImageConfig;
       if (imageConfig.resized == null)
       {
         removeUselessFiles(requestCode, imageConfig);

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -77,7 +77,7 @@ public class MediaUtils
      * @param initialHeight
      * @return updated ImageConfig
      */
-    public static @NonNull ImageConfig getResizedImage(@NonNull final Context context,
+    public static @Nullable ImageConfig getResizedImage(@NonNull final Context context,
                                                        @NonNull final ReadableMap options,
                                                        @NonNull final ImageConfig imageConfig,
                                                        int initialWidth,


### PR DESCRIPTION
## Motivation (required)

Fixes a crash: https://github.com/react-native-community/react-native-image-picker/issues/1196 When resizing is enabled, picking an image file type that is not supported on Android crashes the app. For example some files with the `image/tiff` or `image/heic` mime type.

## Solution (required)

`BitmapFactory.decodeFile` returns null If the specified file name is null, or cannot be decoded into a bitmap. In this case `MediaUtils.getResizedImage` returns null, though its annotation was `nonNull`. As a result the `ImagePickerModule` will crash.

1. I changed the annotation of `MediaUtils.getResizedImage` to nullable.
2. I changed the `ImagePickerModule` to be able to deal with a null response from `MediaUtils.getResizedImage`.

