### PR TITLE
Fix Android Q file creation

### DIFF
--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -45,11 +45,23 @@ public class MediaUtils
                 .append(".jpg")
                 .toString();
 
-        final File path = ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")
-                && ReadableMapUtils.hasAndNotEmptyString(options.getMap("storageOptions"), "path")
-                ? new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), options.getMap("storageOptions").getString("path"))
-                : (!forceLocal ? Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
-                              : reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES));
+        final File path;
+        if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")
+                && ReadableMapUtils.hasAndNotEmptyString(options.getMap("storageOptions"), "path")) {
+            final String customPath = options.getMap("storageOptions").getString("path");
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                // getExternalStoragePublicDirectory is deprecated in Android Q
+                path = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), customPath);
+            } else {
+                path = new File(reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES), customPath);
+            }
+        } else {
+            if (!forceLocal) {
+                path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+            } else {
+                path = reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+            }
+        }
 
         File result = new File(path, filename);
 


### PR DESCRIPTION
`getExternalStoragePublicDirectory` method is deprecated on Android Q, which means the folder is never created on Android Q devices, so we can not take a picture.

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Cannot take a picture with Android Q devices.

## Test Plan (required)

Run the demo app with Android Q device and use the following options on js code:

```
const options = {
      title: 'Select the new video',
      takePhotoButtonTitle: 'Record video...',
      storageOptions: {
        skipBackup: true,
        path: 'images',
      },
      mediaType: 'photo',
    };
```