### PR TITLE
Fix Android URI permission denial bug when app refreshes

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -353,7 +353,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     else
     {
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
-      libraryIntent = new Intent(Intent.ACTION_PICK,
+      libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT,
       MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
 
       if (pickBoth) 


### PR DESCRIPTION
I propose that inside ImagePickerModule.java we use 

`libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT`

instead of 

`libraryIntent = new Intent(Intent.ACTION_PICK`

on line 356:

<img width="588" alt="Screenshot 2020-02-13 at 14 55 35" src="https://user-images.githubusercontent.com/8778176/74437529-ef850f80-4e70-11ea-9dc3-1b812ee85272.png">

for the following reasons:

As of Android M, certain permissions are granted temporarily to the activity that was running at the point when that permission was granted by the client. 

see: **https://stackoverflow.com/questions/37024668/issue-react-native-android-provider-permission-denial-exception**

see: **https://stackoverflow.com/questions/30572261/using-data-from-context-providers-or-requesting-google-photos-read-permission**

In the case of React Native Image Picker on Android, this is fine for once-off accessing and making use of an image that a client selects from Google Photos or any other photo library. I ran into an issue when a user accesses an image and I store the uri to that image on device. In this case, while the uri is saved on device and the user closes and reopens the app, an error will be throw on Android pertaining to denied permissions to the photos provider since the activity that originally requested the permission is no longer running.

Please see screenshot of the issue:

<img width="312" alt="Screenshot 2020-02-13 at 12 02 54" src="https://user-images.githubusercontent.com/8778176/74437259-81d8e380-4e70-11ea-96c4-125d18235513.png">

By making use of "ACTION_OPEN_DOCUMENT", the uri permissions to the image is persisted across activities therefor the error is not raised

