### PR TITLE
Added null check for uri in RealPathUtil.java

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -237,7 +237,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     if (pickVideo) {
       requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
       cameraIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
-      Uri fileUri = getOutputMediaFile(MEDIA_TYPE_VIDEO);  // create a file to save the video in specific folder (this works for video only)
+      Uri fileUri = getOutputMediaFile(reactContext,MEDIA_TYPE_VIDEO);  // create a file to save the video in specific folder (this works for video only)
       cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, fileUri);
       cameraIntent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, videoQuality);
       if (videoDurationLimit > 0) {

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -381,7 +381,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
           } catch (Exception e) {
             // image not in cache
             responseHelper.putString("error", "Could not read photo");
-            responseHelper.putString("uri", uri.toString());
+            responseHelper.putString("uri", uri != null ? uri.toString() : null);
             responseHelper.invokeResponse(callback);
             callback = null;
             return;
@@ -500,7 +500,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   private void updatedResultResponse(@Nullable final Uri uri,
                                      @NonNull final String path) {
-    responseHelper.putString("uri", uri.toString());
+    responseHelper.putString("uri", uri != null ? uri.toString() : null);
     responseHelper.putString("path", path);
 
     if (!noData) {

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -10,6 +10,7 @@ import android.content.pm.ResolveInfo;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
 import android.provider.MediaStore;
 import android.provider.Settings;
 
@@ -370,7 +371,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
       case REQUEST_LAUNCH_IMAGE_LIBRARY:
         uri = data.getData();
-        String realPath = getRealPathFromURI(uri);
+        String realPath = getRealPathFromURI(uri, Environment.DIRECTORY_PICTURES);
         final boolean isUrl = !TextUtils.isEmpty(realPath) &&
                 Patterns.WEB_URL.matcher(realPath).matches();
         if (realPath == null || isUrl) {
@@ -393,7 +394,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       case REQUEST_LAUNCH_VIDEO_LIBRARY:
         if (data != null && data.getData() != null) {
           responseHelper.putString("uri", data.getData().toString());
-          responseHelper.putString("path", getRealPathFromURI(data.getData()));
+          responseHelper.putString("path", getRealPathFromURI(data.getData(),Environment.DIRECTORY_MOVIES));
           responseHelper.invokeResponse(callback);
           callback = null;
         }
@@ -401,7 +402,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
       case REQUEST_LAUNCH_VIDEO_CAPTURE:
         if (data != null && data.getData() != null) {
-          final String path = getRealPathFromURI(data.getData());
+          final String path = getRealPathFromURI(data.getData(),Environment.DIRECTORY_MOVIES);
           responseHelper.putString("uri", data.getData().toString());
           responseHelper.putString("path", path);
           fileScan(reactContext, path);
@@ -608,8 +609,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   }
 
   private @NonNull
-  String getRealPathFromURI(@NonNull final Uri uri) {
-    return RealPathUtil.getRealPathFromURI(reactContext, uri);
+  String getRealPathFromURI(@NonNull final Uri uri,String directoryType) {
+    return RealPathUtil.getRealPathFromURI(reactContext, uri,directoryType);
   }
 
   /**

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -8,8 +8,10 @@ import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Environment;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import android.util.Log;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -25,388 +27,373 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import static android.provider.MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO;
 import static com.imagepicker.ImagePickerModule.REQUEST_LAUNCH_IMAGE_CAPTURE;
 
 /**
  * Created by rusfearuth on 15.03.17.
  */
 
-public class MediaUtils
-{
-    public static @Nullable File createNewFile(@NonNull final Context reactContext,
-                                               @NonNull final ReadableMap options,
-                                               @NonNull final boolean forceLocal)
-    {
-        final String filename = new StringBuilder("image-")
-                .append(UUID.randomUUID().toString())
-                .append(".jpg")
-                .toString();
+public class MediaUtils {
+  private static final String TAG = "MediaUtils";
 
-        // defaults to Public Pictures Directory
-        File path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+  public static @Nullable
+  File createNewFile(@NonNull final Context reactContext,
+                     @NonNull final ReadableMap options,
+                     @NonNull final boolean forceLocal) {
+    final String filename = new StringBuilder("image-")
+            .append(UUID.randomUUID().toString())
+            .append(".jpg")
+            .toString();
 
-        if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")) 
-        {
-            final ReadableMap storageOptions = options.getMap("storageOptions");
+    // defaults to Public Pictures Directory
+    File path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
 
-            if (storageOptions.hasKey("privateDirectory"))
-            {
-                boolean saveToPrivateDirectory = storageOptions.getBoolean("privateDirectory");
-                if (saveToPrivateDirectory)
-                {
-                    // if privateDirectory is set then save to app's private files directory
-                    path = reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-                }
-            }
+    if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")) {
+      final ReadableMap storageOptions = options.getMap("storageOptions");
 
-            if (ReadableMapUtils.hasAndNotEmptyString(storageOptions, "path"))
-            {
-                path = new File(path, storageOptions.getString("path"));
-            }
+      if (storageOptions.hasKey("privateDirectory")) {
+        boolean saveToPrivateDirectory = storageOptions.getBoolean("privateDirectory");
+        if (saveToPrivateDirectory) {
+          // if privateDirectory is set then save to app's private files directory
+          path = reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
         }
-        else if (forceLocal)
-        {
-            path = reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-        }
+      }
 
-        File result = new File(path, filename);
-
-        try
-        {
-            path.mkdirs();
-            result.createNewFile();
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            result = null;
-        }
-
-        return result;
+      if (ReadableMapUtils.hasAndNotEmptyString(storageOptions, "path")) {
+        path = new File(path, storageOptions.getString("path"));
+      }
+    } else if (forceLocal) {
+      path = reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
     }
 
-    /**
-     * Create a resized image to fulfill the maxWidth/maxHeight, quality and rotation values
-     *
-     * @param context
-     * @param options
-     * @param imageConfig
-     * @param initialWidth
-     * @param initialHeight
-     * @return updated ImageConfig
-     */
-    public static @NonNull ImageConfig getResizedImage(@NonNull final Context context,
-                                                       @NonNull final ReadableMap options,
-                                                       @NonNull final ImageConfig imageConfig,
-                                                       int initialWidth,
-                                                       int initialHeight,
-                                                       final int requestCode)
-    {
-        BitmapFactory.Options imageOptions = new BitmapFactory.Options();
-        imageOptions.inScaled = false;
-        imageOptions.inSampleSize = 1;
+    File result = new File(path, filename);
 
-        if (imageConfig.maxWidth != 0 || imageConfig.maxHeight != 0) {
-            while ((imageConfig.maxWidth == 0 || initialWidth > 2 * imageConfig.maxWidth) &&
-                   (imageConfig.maxHeight == 0 || initialHeight > 2 * imageConfig.maxHeight)) {
-                imageOptions.inSampleSize *= 2;
-                initialHeight /= 2;
-                initialWidth /= 2;
-            }
-        }
-
-        Bitmap photo = BitmapFactory.decodeFile(imageConfig.original.getAbsolutePath(), imageOptions);
-
-        if (photo == null)
-        {
-            return null;
-        }
-
-        ImageConfig result = imageConfig;
-
-        Bitmap scaledPhoto = null;
-        if (imageConfig.maxWidth == 0 || imageConfig.maxWidth > initialWidth)
-        {
-            result = result.withMaxWidth(initialWidth);
-        }
-        if (imageConfig.maxHeight == 0 || imageConfig.maxWidth > initialHeight)
-        {
-            result = result.withMaxHeight(initialHeight);
-        }
-
-        double widthRatio = (double) result.maxWidth / initialWidth;
-        double heightRatio = (double) result.maxHeight / initialHeight;
-
-        double ratio = (widthRatio < heightRatio)
-                ? widthRatio
-                : heightRatio;
-
-        Matrix matrix = new Matrix();
-        matrix.postRotate(result.rotation);
-        matrix.postScale((float) ratio, (float) ratio);
-
-        ExifInterface exif;
-        try
-        {
-            exif = new ExifInterface(result.original.getAbsolutePath());
-
-            int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0);
-
-            switch (orientation)
-            {
-                case 6:
-                    matrix.postRotate(90);
-                    break;
-                case 3:
-                    matrix.postRotate(180);
-                    break;
-                case 8:
-                    matrix.postRotate(270);
-                    break;
-            }
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-
-        scaledPhoto = Bitmap.createBitmap(photo, 0, 0, photo.getWidth(), photo.getHeight(), matrix, true);
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        scaledPhoto.compress(Bitmap.CompressFormat.JPEG, result.quality, bytes);
-
-        final boolean forceLocal = requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE;
-        final File resized = createNewFile(context, options, !forceLocal);
-
-        if (resized == null)
-        {
-            if (photo != null)
-            {
-                photo.recycle();
-                photo = null;
-            }
-            if (scaledPhoto != null)
-            {
-                scaledPhoto.recycle();
-                scaledPhoto = null;
-            }
-            return imageConfig;
-        }
-
-        result = result.withResizedFile(resized);
-
-        try (FileOutputStream fos = new FileOutputStream(result.resized))
-        {
-            bytes.writeTo(fos);
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-
-        if (photo != null)
-        {
-            photo.recycle();
-            photo = null;
-        }
-        if (scaledPhoto != null)
-        {
-            scaledPhoto.recycle();
-            scaledPhoto = null;
-        }
-        return result;
+    try {
+      path.mkdirs();
+      result.createNewFile();
+    } catch (IOException e) {
+      e.printStackTrace();
+      result = null;
     }
 
-    public static void removeUselessFiles(final int requestCode,
-                                          @NonNull final ImageConfig imageConfig)
-    {
-        if (requestCode != ImagePickerModule.REQUEST_LAUNCH_IMAGE_CAPTURE)
-        {
-            return;
-        }
+    return result;
+  }
 
-        if (imageConfig.original != null && imageConfig.original.exists())
-        {
-            imageConfig.original.delete();
-        }
+  /**
+   * Create a resized image to fulfill the maxWidth/maxHeight, quality and rotation values
+   *
+   * @param context
+   * @param options
+   * @param imageConfig
+   * @param initialWidth
+   * @param initialHeight
+   * @return updated ImageConfig
+   */
+  public static @NonNull
+  ImageConfig getResizedImage(@NonNull final Context context,
+                              @NonNull final ReadableMap options,
+                              @NonNull final ImageConfig imageConfig,
+                              int initialWidth,
+                              int initialHeight,
+                              final int requestCode) {
+    BitmapFactory.Options imageOptions = new BitmapFactory.Options();
+    imageOptions.inScaled = false;
+    imageOptions.inSampleSize = 1;
 
-        if (imageConfig.resized != null && imageConfig.resized.exists())
-        {
-            imageConfig.resized.delete();
-        }
+    if (imageConfig.maxWidth != 0 || imageConfig.maxHeight != 0) {
+      while ((imageConfig.maxWidth == 0 || initialWidth > 2 * imageConfig.maxWidth) &&
+              (imageConfig.maxHeight == 0 || initialHeight > 2 * imageConfig.maxHeight)) {
+        imageOptions.inSampleSize *= 2;
+        initialHeight /= 2;
+        initialWidth /= 2;
+      }
     }
 
-    public static void fileScan(@Nullable final Context reactContext,
-                                @NonNull final String path)
-    {
-        if (reactContext == null)
-        {
-            return;
-        }
-        MediaScannerConnection.scanFile(reactContext,
-                new String[] { path }, null,
-                new MediaScannerConnection.OnScanCompletedListener()
-                {
-                    public void onScanCompleted(String path, Uri uri)
-                    {
-                        Log.i("TAG", new StringBuilder("Finished scanning ").append(path).toString());
-                    }
-                });
+    Bitmap photo = BitmapFactory.decodeFile(imageConfig.original.getAbsolutePath(), imageOptions);
+
+    if (photo == null) {
+      return null;
     }
 
-    public static ReadExifResult readExifInterface(@NonNull ResponseHelper responseHelper,
-                                                   @NonNull final ImageConfig imageConfig)
-    {
-        ReadExifResult result;
-        int currentRotation = 0;
+    ImageConfig result = imageConfig;
 
-        try
-        {
-            ExifInterface exif = new ExifInterface(imageConfig.original.getAbsolutePath());
-
-            // extract lat, long, and timestamp and add to the response
-            float[] latlng = new float[2];
-            exif.getLatLong(latlng);
-            float latitude = latlng[0];
-            float longitude = latlng[1];
-            if(latitude != 0f || longitude != 0f)
-            {
-                responseHelper.putDouble("latitude", latitude);
-                responseHelper.putDouble("longitude", longitude);
-            }
-
-            final String timestamp = exif.getAttribute(ExifInterface.TAG_DATETIME);
-            final SimpleDateFormat exifDatetimeFormat = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
-
-            final DateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-            try
-            {
-                final String isoFormatString = new StringBuilder(isoFormat.format(exifDatetimeFormat.parse(timestamp)))
-                        .append("Z").toString();
-                responseHelper.putString("timestamp", isoFormatString);
-            }
-            catch (Exception e) {}
-
-            int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
-            boolean isVertical = true;
-            switch (orientation) {
-                case ExifInterface.ORIENTATION_ROTATE_270:
-                    isVertical = false;
-                    currentRotation = 270;
-                    break;
-                case ExifInterface.ORIENTATION_ROTATE_90:
-                    isVertical = false;
-                    currentRotation = 90;
-                    break;
-                case ExifInterface.ORIENTATION_ROTATE_180:
-                    currentRotation = 180;
-                    break;
-            }
-            responseHelper.putInt("originalRotation", currentRotation);
-            responseHelper.putBoolean("isVertical", isVertical);
-            result = new ReadExifResult(currentRotation, null);
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            result = new ReadExifResult(currentRotation, e);
-        }
-
-        return result;
+    Bitmap scaledPhoto = null;
+    if (imageConfig.maxWidth == 0 || imageConfig.maxWidth > initialWidth) {
+      result = result.withMaxWidth(initialWidth);
+    }
+    if (imageConfig.maxHeight == 0 || imageConfig.maxWidth > initialHeight) {
+      result = result.withMaxHeight(initialHeight);
     }
 
-    public static @Nullable RolloutPhotoResult rolloutPhotoFromCamera(@NonNull final ImageConfig imageConfig)
-    {
-        RolloutPhotoResult result = null;
-        final File oldFile = imageConfig.resized == null ? imageConfig.original: imageConfig.resized;
-        final File newDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
-        final File newFile = new File(newDir.getPath(), oldFile.getName());
+    double widthRatio = (double) result.maxWidth / initialWidth;
+    double heightRatio = (double) result.maxHeight / initialHeight;
 
-        try
-        {
-            moveFile(oldFile, newFile);
-            ImageConfig newImageConfig;
-            if (imageConfig.resized != null)
-            {
-                newImageConfig = imageConfig.withResizedFile(newFile);
-            }
-            else
-            {
-                newImageConfig = imageConfig.withOriginalFile(newFile);
-            }
-            result = new RolloutPhotoResult(newImageConfig, null);
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            result = new RolloutPhotoResult(imageConfig, e);
-        }
-        return result;
+    double ratio = (widthRatio < heightRatio)
+            ? widthRatio
+            : heightRatio;
+
+    Matrix matrix = new Matrix();
+    matrix.postRotate(result.rotation);
+    matrix.postScale((float) ratio, (float) ratio);
+
+    ExifInterface exif;
+    try {
+      exif = new ExifInterface(result.original.getAbsolutePath());
+
+      int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0);
+
+      switch (orientation) {
+        case 6:
+          matrix.postRotate(90);
+          break;
+        case 3:
+          matrix.postRotate(180);
+          break;
+        case 8:
+          matrix.postRotate(270);
+          break;
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
     }
 
-    /**
-     * Move a file from one location to another.
-     *
-     * This is done via copy + deletion, because Android will throw an error
-     * if you try to move a file across mount points, e.g. to the SD card.
-     */
-    private static void moveFile(@NonNull final File oldFile,
-                                 @NonNull final File newFile) throws IOException
-    {
-        FileChannel oldChannel = null;
-        FileChannel newChannel = null;
+    scaledPhoto = Bitmap.createBitmap(photo, 0, 0, photo.getWidth(), photo.getHeight(), matrix, true);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    scaledPhoto.compress(Bitmap.CompressFormat.JPEG, result.quality, bytes);
 
-        try
-        {
-            oldChannel = new FileInputStream(oldFile).getChannel();
-            newChannel = new FileOutputStream(newFile).getChannel();
-            oldChannel.transferTo(0, oldChannel.size(), newChannel);
+    final boolean forceLocal = requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE;
+    final File resized = createNewFile(context, options, !forceLocal);
 
-            oldFile.delete();
-        }
-        finally
-        {
-            try
-            {
-                if (oldChannel != null) oldChannel.close();
-                if (newChannel != null) newChannel.close();
-            }
-            catch (IOException e)
-            {
-                e.printStackTrace();
-            }
-        }
+    if (resized == null) {
+      if (photo != null) {
+        photo.recycle();
+        photo = null;
+      }
+      if (scaledPhoto != null) {
+        scaledPhoto.recycle();
+        scaledPhoto = null;
+      }
+      return imageConfig;
     }
 
+    result = result.withResizedFile(resized);
 
-    public static class RolloutPhotoResult
-    {
-        public final ImageConfig imageConfig;
-        public final Throwable error;
-
-        public RolloutPhotoResult(@NonNull final ImageConfig imageConfig,
-                                  @Nullable final Throwable error)
-        {
-            this.imageConfig = imageConfig;
-            this.error = error;
-        }
+    try (FileOutputStream fos = new FileOutputStream(result.resized)) {
+      bytes.writeTo(fos);
+    } catch (IOException e) {
+      e.printStackTrace();
     }
 
-
-    public static class ReadExifResult
-    {
-        public final int currentRotation;
-        public final Throwable error;
-
-        public ReadExifResult(int currentRotation,
-                              @Nullable final Throwable error)
-        {
-            this.currentRotation = currentRotation;
-            this.error = error;
-        }
+    if (photo != null) {
+      photo.recycle();
+      photo = null;
     }
+    if (scaledPhoto != null) {
+      scaledPhoto.recycle();
+      scaledPhoto = null;
+    }
+    return result;
+  }
+
+  public static void removeUselessFiles(final int requestCode,
+                                        @NonNull final ImageConfig imageConfig) {
+    if (requestCode != ImagePickerModule.REQUEST_LAUNCH_IMAGE_CAPTURE) {
+      return;
+    }
+
+    if (imageConfig.original != null && imageConfig.original.exists()) {
+      imageConfig.original.delete();
+    }
+
+    if (imageConfig.resized != null && imageConfig.resized.exists()) {
+      imageConfig.resized.delete();
+    }
+  }
+
+  public static void fileScan(@Nullable final Context reactContext,
+                              @NonNull final String path) {
+    if (reactContext == null) {
+      return;
+    }
+    MediaScannerConnection.scanFile(reactContext,
+            new String[]{path}, null,
+            new MediaScannerConnection.OnScanCompletedListener() {
+              public void onScanCompleted(String path, Uri uri) {
+                Log.i("TAG", new StringBuilder("Finished scanning ").append(path).toString());
+              }
+            });
+  }
+
+  public static ReadExifResult readExifInterface(@NonNull ResponseHelper responseHelper,
+                                                 @NonNull final ImageConfig imageConfig) {
+    ReadExifResult result;
+    int currentRotation = 0;
+
+    try {
+      ExifInterface exif = new ExifInterface(imageConfig.original.getAbsolutePath());
+
+      // extract lat, long, and timestamp and add to the response
+      float[] latlng = new float[2];
+      exif.getLatLong(latlng);
+      float latitude = latlng[0];
+      float longitude = latlng[1];
+      if (latitude != 0f || longitude != 0f) {
+        responseHelper.putDouble("latitude", latitude);
+        responseHelper.putDouble("longitude", longitude);
+      }
+
+      final String timestamp = exif.getAttribute(ExifInterface.TAG_DATETIME);
+      final SimpleDateFormat exifDatetimeFormat = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+
+      final DateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+      isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+      try {
+        final String isoFormatString = new StringBuilder(isoFormat.format(exifDatetimeFormat.parse(timestamp)))
+                .append("Z").toString();
+        responseHelper.putString("timestamp", isoFormatString);
+      } catch (Exception e) {
+      }
+
+      int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+      boolean isVertical = true;
+      switch (orientation) {
+        case ExifInterface.ORIENTATION_ROTATE_270:
+          isVertical = false;
+          currentRotation = 270;
+          break;
+        case ExifInterface.ORIENTATION_ROTATE_90:
+          isVertical = false;
+          currentRotation = 90;
+          break;
+        case ExifInterface.ORIENTATION_ROTATE_180:
+          currentRotation = 180;
+          break;
+      }
+      responseHelper.putInt("originalRotation", currentRotation);
+      responseHelper.putBoolean("isVertical", isVertical);
+      result = new ReadExifResult(currentRotation, null);
+    } catch (IOException e) {
+      e.printStackTrace();
+      result = new ReadExifResult(currentRotation, e);
+    }
+
+    return result;
+  }
+
+  public static @Nullable
+  RolloutPhotoResult rolloutPhotoFromCamera(@NonNull final ImageConfig imageConfig) {
+    RolloutPhotoResult result = null;
+    final File oldFile = imageConfig.resized == null ? imageConfig.original : imageConfig.resized;
+    final File newDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
+    final File newFile = new File(newDir.getPath(), oldFile.getName());
+
+    try {
+      moveFile(oldFile, newFile);
+      ImageConfig newImageConfig;
+      if (imageConfig.resized != null) {
+        newImageConfig = imageConfig.withResizedFile(newFile);
+      } else {
+        newImageConfig = imageConfig.withOriginalFile(newFile);
+      }
+      result = new RolloutPhotoResult(newImageConfig, null);
+    } catch (IOException e) {
+      e.printStackTrace();
+      result = new RolloutPhotoResult(imageConfig, e);
+    }
+    return result;
+  }
+
+  /**
+   * Move a file from one location to another.
+   * <p>
+   * This is done via copy + deletion, because Android will throw an error
+   * if you try to move a file across mount points, e.g. to the SD card.
+   */
+  private static void moveFile(@NonNull final File oldFile,
+                               @NonNull final File newFile) throws IOException {
+    FileChannel oldChannel = null;
+    FileChannel newChannel = null;
+
+    try {
+      oldChannel = new FileInputStream(oldFile).getChannel();
+      newChannel = new FileOutputStream(newFile).getChannel();
+      oldChannel.transferTo(0, oldChannel.size(), newChannel);
+
+      oldFile.delete();
+    } finally {
+      try {
+        if (oldChannel != null) oldChannel.close();
+        if (newChannel != null) newChannel.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+
+  public static class RolloutPhotoResult {
+    public final ImageConfig imageConfig;
+    public final Throwable error;
+
+    public RolloutPhotoResult(@NonNull final ImageConfig imageConfig,
+                              @Nullable final Throwable error) {
+      this.imageConfig = imageConfig;
+      this.error = error;
+    }
+  }
+
+
+  public static class ReadExifResult {
+    public final int currentRotation;
+    public final Throwable error;
+
+    public ReadExifResult(int currentRotation,
+                          @Nullable final Throwable error) {
+      this.currentRotation = currentRotation;
+      this.error = error;
+    }
+  }
+
+  // Please check this : https://stackoverflow.com/questions/18120775/android-android-provider-mediastore-action-video-capture-return-null-onactivityr
+
+  public static Uri getOutputMediaFile(int type) {
+    // To be safe, you should check that the SDCard is mounted
+
+    if (Environment.getExternalStorageState() != null) {
+      // this works for Android 2.2 and above
+      File mediaStorageDir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES), "SMW_VIDEO");
+
+      // This location works best if you want the created images to be shared
+      // between applications and persist after your app has been uninstalled.
+
+      // Create the storage directory if it does not exist
+      if (!mediaStorageDir.exists()) {
+        if (!mediaStorageDir.mkdirs()) {
+          Log.d(TAG, "failed to create directory");
+          return null;
+        }
+      }
+
+      // Create a media file name
+      String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+      File mediaFile;
+      if (type == MEDIA_TYPE_VIDEO) {
+        mediaFile = new File(mediaStorageDir.getPath() + File.separator +
+                "VID_" + timeStamp + ".mp4");
+      } else {
+        return null;
+      }
+
+      return Uri.fromFile(mediaFile);
+    }
+
+    return null;
+  }
 }
+

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -7,10 +7,12 @@ import android.graphics.Matrix;
 import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 
 import android.util.Log;
 
@@ -362,7 +364,7 @@ public class MediaUtils {
 
   // Please check this : https://stackoverflow.com/questions/18120775/android-android-provider-mediastore-action-video-capture-return-null-onactivityr
 
-  public static Uri getOutputMediaFile(int type) {
+  public static Uri getOutputMediaFile(Context context, int type) {
     // To be safe, you should check that the SDCard is mounted
 
     if (Environment.getExternalStorageState() != null) {
@@ -389,9 +391,15 @@ public class MediaUtils {
       } else {
         return null;
       }
-
-      return Uri.fromFile(mediaFile);
-    }
+      Uri resultUri;
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        resultUri = Uri.fromFile(mediaFile);
+      } else {
+        resultUri = FileProvider.getUriForFile(context,
+                context.getApplicationContext().getPackageName() + ".provider",
+                mediaFile);
+      }
+      return resultUri;    }
 
     return null;
   }

--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -9,6 +9,7 @@ import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.content.ContentUris;
 import android.os.Environment;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
@@ -17,185 +18,186 @@ import java.io.File;
 
 public class RealPathUtil {
 
-	public static @Nullable Uri compatUriFromFile(@NonNull final Context context,
-												  @NonNull final File file) {
-		Uri result = null;
-		if (Build.VERSION.SDK_INT < 21) {
-			result = Uri.fromFile(file);
-		}
-		else {
-			final String packageName = context.getApplicationContext().getPackageName();
-			final String authority =  new StringBuilder(packageName).append(".provider").toString();
-			try {
-				result = FileProvider.getUriForFile(context, authority, file);
-			}
-			catch(IllegalArgumentException e) {
-				e.printStackTrace();
-			}
-		}
-		return result;
-	}
+    public static @Nullable
+    Uri compatUriFromFile(@NonNull final Context context,
+                          @NonNull final File file) {
+        Uri result = null;
+        if (Build.VERSION.SDK_INT < 21) {
+            result = Uri.fromFile(file);
+        } else {
+            final String packageName = context.getApplicationContext().getPackageName();
+            final String authority = new StringBuilder(packageName).append(".provider").toString();
+            try {
+                result = FileProvider.getUriForFile(context, authority, file);
+            } catch (IllegalArgumentException e) {
+                e.printStackTrace();
+            }
+        }
+        return result;
+    }
 
-	@SuppressLint("NewApi")
-	public static @Nullable String getRealPathFromURI(@NonNull final Context context,
-													  @NonNull final Uri uri) {
+    @SuppressLint("NewApi")
+    public static @Nullable
+    String getRealPathFromURI(@NonNull final Context context,
+                              @NonNull final Uri uri) {
 
-		final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+        if (uri != null) {
+            // DocumentProvider
+            if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+                // ExternalStorageProvider
+                if (isExternalStorageDocument(uri)) {
+                    final String docId = DocumentsContract.getDocumentId(uri);
+                    final String[] split = docId.split(":");
+                    final String type = split[0];
 
-		// DocumentProvider
-		if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-			// ExternalStorageProvider
-			if (isExternalStorageDocument(uri)) {
-				final String docId = DocumentsContract.getDocumentId(uri);
-				final String[] split = docId.split(":");
-				final String type = split[0];
+                    if ("primary".equalsIgnoreCase(type)) {
+                        return Environment.getExternalStorageDirectory() + "/" + split[1];
+                    }
 
-				if ("primary".equalsIgnoreCase(type)) {
-					return Environment.getExternalStorageDirectory() + "/" + split[1];
-				}
+                    // TODO handle non-primary volumes
+                }
+                // DownloadsProvider
+                else if (isDownloadsDocument(uri)) {
 
-				// TODO handle non-primary volumes
-			}
-			// DownloadsProvider
-			else if (isDownloadsDocument(uri)) {
+                    final String id = DocumentsContract.getDocumentId(uri);
+                    final Uri contentUri = ContentUris.withAppendedId(
+                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 
-				final String id = DocumentsContract.getDocumentId(uri);
-				final Uri contentUri = ContentUris.withAppendedId(
-						Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+                    return getDataColumn(context, contentUri, null, null);
+                }
+                // MediaProvider
+                else if (isMediaDocument(uri)) {
+                    final String docId = DocumentsContract.getDocumentId(uri);
+                    final String[] split = docId.split(":");
+                    final String type = split[0];
 
-				return getDataColumn(context, contentUri, null, null);
-			}
-			// MediaProvider
-			else if (isMediaDocument(uri)) {
-				final String docId = DocumentsContract.getDocumentId(uri);
-				final String[] split = docId.split(":");
-				final String type = split[0];
+                    Uri contentUri = null;
+                    if ("image".equals(type)) {
+                        contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                    } else if ("video".equals(type)) {
+                        contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                    } else if ("audio".equals(type)) {
+                        contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                    }
 
-				Uri contentUri = null;
-				if ("image".equals(type)) {
-					contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-				} else if ("video".equals(type)) {
-					contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-				} else if ("audio".equals(type)) {
-					contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-				}
+                    final String selection = "_id=?";
+                    final String[] selectionArgs = new String[]{
+                            split[1]
+                    };
 
-				final String selection = "_id=?";
-				final String[] selectionArgs = new String[] {
-						split[1]
-				};
+                    return getDataColumn(context, contentUri, selection, selectionArgs);
+                }
+            }
+            // MediaStore (and general)
+            else if ("content".equalsIgnoreCase(uri.getScheme())) {
 
-				return getDataColumn(context, contentUri, selection, selectionArgs);
-			}
-		}
-		// MediaStore (and general)
-		else if ("content".equalsIgnoreCase(uri.getScheme())) {
+                // Return the remote address
+                if (isGooglePhotosUri(uri))
+                    return uri.getLastPathSegment();
 
-			// Return the remote address
-			if (isGooglePhotosUri(uri))
-				return uri.getLastPathSegment();
+                if (isFileProviderUri(context, uri))
+                    return getFileProviderPath(context, uri);
 
-			if (isFileProviderUri(context, uri))
-				return getFileProviderPath(context, uri);
+                return getDataColumn(context, uri, null, null);
+            }
+            // File
+            else if ("file".equalsIgnoreCase(uri.getScheme())) {
+                return uri.getPath();
+            }
+        }
 
-			return getDataColumn(context, uri, null, null);
-		}
-		// File
-		else if ("file".equalsIgnoreCase(uri.getScheme())) {
-			return uri.getPath();
-		}
+        return null;
+    }
 
-		return null;
-	}
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context       The context.
+     * @param uri           The Uri to query.
+     * @param selection     (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    public static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
 
-	/**
-	 * Get the value of the data column for this Uri. This is useful for
-	 * MediaStore Uris, and other file-based ContentProviders.
-	 *
-	 * @param context The context.
-	 * @param uri The Uri to query.
-	 * @param selection (Optional) Filter used in the query.
-	 * @param selectionArgs (Optional) Selection arguments used in the query.
-	 * @return The value of the _data column, which is typically a file path.
-	 */
-	public static String getDataColumn(Context context, Uri uri, String selection,
-	                                   String[] selectionArgs) {
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
 
-		Cursor cursor = null;
-		final String column = "_data";
-		final String[] projection = {
-				column
-		};
-
-		try {
-			cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-					null);
-			if (cursor != null && cursor.moveToFirst()) {
-				final int index = cursor.getColumnIndexOrThrow(column);
-				return cursor.getString(index);
-			}
-		} finally {
-			if (cursor != null)
-				cursor.close();
-		}
-		return null;
-	}
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
 
 
-	/**
-	 * @param uri The Uri to check.
-	 * @return Whether the Uri authority is ExternalStorageProvider.
-	 */
-	public static boolean isExternalStorageDocument(Uri uri) {
-		return "com.android.externalstorage.documents".equals(uri.getAuthority());
-	}
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    public static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
 
-	/**
-	 * @param uri The Uri to check.
-	 * @return Whether the Uri authority is DownloadsProvider.
-	 */
-	public static boolean isDownloadsDocument(Uri uri) {
-		return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-	}
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    public static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
 
-	/**
-	 * @param uri The Uri to check.
-	 * @return Whether the Uri authority is MediaProvider.
-	 */
-	public static boolean isMediaDocument(Uri uri) {
-		return "com.android.providers.media.documents".equals(uri.getAuthority());
-	}
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    public static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
 
-	/**
-	 * @param uri The Uri to check.
-	 * @return Whether the Uri authority is Google Photos.
-	 */
-	public static boolean isGooglePhotosUri(@NonNull final Uri uri) {
-		return "com.google.android.apps.photos.content".equals(uri.getAuthority());
-	}
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    public static boolean isGooglePhotosUri(@NonNull final Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
 
-	/**
-	 * @param context The Application context
-	 * @param uri The Uri is checked by functions
-	 * @return Whether the Uri authority is FileProvider
-	 */
-	public static boolean isFileProviderUri(@NonNull final Context context,
-	                                        @NonNull final Uri uri) {
-		final String packageName = context.getPackageName();
-		final String authority = new StringBuilder(packageName).append(".provider").toString();
-		return authority.equals(uri.getAuthority());
-	}
+    /**
+     * @param context The Application context
+     * @param uri     The Uri is checked by functions
+     * @return Whether the Uri authority is FileProvider
+     */
+    public static boolean isFileProviderUri(@NonNull final Context context,
+                                            @NonNull final Uri uri) {
+        final String packageName = context.getPackageName();
+        final String authority = new StringBuilder(packageName).append(".provider").toString();
+        return authority.equals(uri.getAuthority());
+    }
 
-	/**
-	 * @param context The Application context
-	 * @param uri The Uri is checked by functions
-	 * @return File path or null if file is missing
-	 */
-	public static @Nullable String getFileProviderPath(@NonNull final Context context,
-	                                                   @NonNull final Uri uri)
-	{
-		final File appDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-		final File file = new File(appDir, uri.getLastPathSegment());
-		return file.exists() ? file.toString(): null;
-	}
+    /**
+     * @param context The Application context
+     * @param uri     The Uri is checked by functions
+     * @return File path or null if file is missing
+     */
+    public static @Nullable
+    String getFileProviderPath(@NonNull final Context context,
+                               @NonNull final Uri uri) {
+        final File appDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        final File file = new File(appDir, uri.getLastPathSegment());
+        return file.exists() ? file.toString() : null;
+    }
 }

--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -18,186 +18,191 @@ import java.io.File;
 
 public class RealPathUtil {
 
-    public static @Nullable
-    Uri compatUriFromFile(@NonNull final Context context,
-                          @NonNull final File file) {
-        Uri result = null;
-        if (Build.VERSION.SDK_INT < 21) {
-            result = Uri.fromFile(file);
-        } else {
-            final String packageName = context.getApplicationContext().getPackageName();
-            final String authority = new StringBuilder(packageName).append(".provider").toString();
-            try {
-                result = FileProvider.getUriForFile(context, authority, file);
-            } catch (IllegalArgumentException e) {
-                e.printStackTrace();
-            }
-        }
-        return result;
-    }
+	public static @Nullable
+	Uri compatUriFromFile(@NonNull final Context context,
+												@NonNull final File file) {
+		Uri result = null;
+		if (Build.VERSION.SDK_INT < 21) {
+			result = Uri.fromFile(file);
+		} else {
+			final String packageName = context.getApplicationContext().getPackageName();
+			final String authority = new StringBuilder(packageName).append(".provider").toString();
+			try {
+				result = FileProvider.getUriForFile(context, authority, file);
+			} catch (IllegalArgumentException e) {
+				e.printStackTrace();
+			}
+		}
+		return result;
+	}
 
-    @SuppressLint("NewApi")
-    public static @Nullable
-    String getRealPathFromURI(@NonNull final Context context,
-                              @NonNull final Uri uri) {
+	@SuppressLint("NewApi")
+	public static @Nullable
+	String getRealPathFromURI(@NonNull final Context context,
+														@NonNull final Uri uri, @NonNull String directoryType) {
 
-        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
-        if (uri != null) {
-            // DocumentProvider
-            if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-                // ExternalStorageProvider
-                if (isExternalStorageDocument(uri)) {
-                    final String docId = DocumentsContract.getDocumentId(uri);
-                    final String[] split = docId.split(":");
-                    final String type = split[0];
+		final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+		if (uri != null) {
+			// DocumentProvider
+			if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+				// ExternalStorageProvider
+				if (isExternalStorageDocument(uri)) {
+					final String docId = DocumentsContract.getDocumentId(uri);
+					final String[] split = docId.split(":");
+					final String type = split[0];
 
-                    if ("primary".equalsIgnoreCase(type)) {
-                        return Environment.getExternalStorageDirectory() + "/" + split[1];
-                    }
+					if ("primary".equalsIgnoreCase(type)) {
+						return Environment.getExternalStorageDirectory() + "/" + split[1];
+					}
 
-                    // TODO handle non-primary volumes
-                }
-                // DownloadsProvider
-                else if (isDownloadsDocument(uri)) {
+					// TODO handle non-primary volumes
+				}
+				// DownloadsProvider
+				else if (isDownloadsDocument(uri)) {
 
-                    final String id = DocumentsContract.getDocumentId(uri);
-                    final Uri contentUri = ContentUris.withAppendedId(
-                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+					final String id = DocumentsContract.getDocumentId(uri);
+					final Uri contentUri = ContentUris.withAppendedId(
+						Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 
-                    return getDataColumn(context, contentUri, null, null);
-                }
-                // MediaProvider
-                else if (isMediaDocument(uri)) {
-                    final String docId = DocumentsContract.getDocumentId(uri);
-                    final String[] split = docId.split(":");
-                    final String type = split[0];
+					return getDataColumn(context, contentUri, null, null);
+				}
+				// MediaProvider
+				else if (isMediaDocument(uri)) {
+					final String docId = DocumentsContract.getDocumentId(uri);
+					final String[] split = docId.split(":");
+					final String type = split[0];
 
-                    Uri contentUri = null;
-                    if ("image".equals(type)) {
-                        contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                    } else if ("video".equals(type)) {
-                        contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                    } else if ("audio".equals(type)) {
-                        contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                    }
+					Uri contentUri = null;
+					if ("image".equals(type)) {
+						contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+					} else if ("video".equals(type)) {
+						contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+					} else if ("audio".equals(type)) {
+						contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+					}
 
-                    final String selection = "_id=?";
-                    final String[] selectionArgs = new String[]{
-                            split[1]
-                    };
+					final String selection = "_id=?";
+					final String[] selectionArgs = new String[]{
+						split[1]
+					};
 
-                    return getDataColumn(context, contentUri, selection, selectionArgs);
-                }
-            }
-            // MediaStore (and general)
-            else if ("content".equalsIgnoreCase(uri.getScheme())) {
+					return getDataColumn(context, contentUri, selection, selectionArgs);
+				}
+			}
+			// MediaStore (and general)
+			else if ("content".equalsIgnoreCase(uri.getScheme())) {
 
-                // Return the remote address
-                if (isGooglePhotosUri(uri))
-                    return uri.getLastPathSegment();
+				// Return the remote address
+				if (isGooglePhotosUri(uri))
+					return uri.getLastPathSegment();
 
-                if (isFileProviderUri(context, uri))
-                    return getFileProviderPath(context, uri);
+				if (isFileProviderUri(context, uri))
+					return getFileProviderPath(context, uri, directoryType);
 
-                return getDataColumn(context, uri, null, null);
-            }
-            // File
-            else if ("file".equalsIgnoreCase(uri.getScheme())) {
-                return uri.getPath();
-            }
-        }
+				return getDataColumn(context, uri, null, null);
+			}
+			// File
+			else if ("file".equalsIgnoreCase(uri.getScheme())) {
+				return uri.getPath();
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * Get the value of the data column for this Uri. This is useful for
-     * MediaStore Uris, and other file-based ContentProviders.
-     *
-     * @param context       The context.
-     * @param uri           The Uri to query.
-     * @param selection     (Optional) Filter used in the query.
-     * @param selectionArgs (Optional) Selection arguments used in the query.
-     * @return The value of the _data column, which is typically a file path.
-     */
-    public static String getDataColumn(Context context, Uri uri, String selection,
-                                       String[] selectionArgs) {
+	/**
+	 * Get the value of the data column for this Uri. This is useful for
+	 * MediaStore Uris, and other file-based ContentProviders.
+	 *
+	 * @param context       The context.
+	 * @param uri           The Uri to query.
+	 * @param selection     (Optional) Filter used in the query.
+	 * @param selectionArgs (Optional) Selection arguments used in the query.
+	 * @return The value of the _data column, which is typically a file path.
+	 */
+	public static String getDataColumn(Context context, Uri uri, String selection,
+																		 String[] selectionArgs) {
 
-        Cursor cursor = null;
-        final String column = "_data";
-        final String[] projection = {
-                column
-        };
+		Cursor cursor = null;
+		final String column = "_data";
+		final String[] projection = {
+			column
+		};
 
-        try {
-            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                    null);
-            if (cursor != null && cursor.moveToFirst()) {
-                final int index = cursor.getColumnIndexOrThrow(column);
-                return cursor.getString(index);
-            }
-        } finally {
-            if (cursor != null)
-                cursor.close();
-        }
-        return null;
-    }
+		try {
+			cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+				null);
+			if (cursor != null && cursor.moveToFirst()) {
+				final int index = cursor.getColumnIndexOrThrow(column);
+				return cursor.getString(index);
+			}
+		} finally {
+			if (cursor != null)
+				cursor.close();
+		}
+		return null;
+	}
 
 
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is ExternalStorageProvider.
-     */
-    public static boolean isExternalStorageDocument(Uri uri) {
-        return "com.android.externalstorage.documents".equals(uri.getAuthority());
-    }
+	/**
+	 * @param uri The Uri to check.
+	 * @return Whether the Uri authority is ExternalStorageProvider.
+	 */
+	public static boolean isExternalStorageDocument(Uri uri) {
+		return "com.android.externalstorage.documents".equals(uri.getAuthority());
+	}
 
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is DownloadsProvider.
-     */
-    public static boolean isDownloadsDocument(Uri uri) {
-        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-    }
+	/**
+	 * @param uri The Uri to check.
+	 * @return Whether the Uri authority is DownloadsProvider.
+	 */
+	public static boolean isDownloadsDocument(Uri uri) {
+		return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+	}
 
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is MediaProvider.
-     */
-    public static boolean isMediaDocument(Uri uri) {
-        return "com.android.providers.media.documents".equals(uri.getAuthority());
-    }
+	/**
+	 * @param uri The Uri to check.
+	 * @return Whether the Uri authority is MediaProvider.
+	 */
+	public static boolean isMediaDocument(Uri uri) {
+		return "com.android.providers.media.documents".equals(uri.getAuthority());
+	}
 
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is Google Photos.
-     */
-    public static boolean isGooglePhotosUri(@NonNull final Uri uri) {
-        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
-    }
+	/**
+	 * @param uri The Uri to check.
+	 * @return Whether the Uri authority is Google Photos.
+	 */
+	public static boolean isGooglePhotosUri(@NonNull final Uri uri) {
+		return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+	}
 
-    /**
-     * @param context The Application context
-     * @param uri     The Uri is checked by functions
-     * @return Whether the Uri authority is FileProvider
-     */
-    public static boolean isFileProviderUri(@NonNull final Context context,
-                                            @NonNull final Uri uri) {
-        final String packageName = context.getPackageName();
-        final String authority = new StringBuilder(packageName).append(".provider").toString();
-        return authority.equals(uri.getAuthority());
-    }
+	/**
+	 * @param context The Application context
+	 * @param uri     The Uri is checked by functions
+	 * @return Whether the Uri authority is FileProvider
+	 */
+	public static boolean isFileProviderUri(@NonNull final Context context,
+																					@NonNull final Uri uri) {
+		final String packageName = context.getPackageName();
+		final String authority = new StringBuilder(packageName).append(".provider").toString();
+		return authority.equals(uri.getAuthority());
+	}
 
-    /**
-     * @param context The Application context
-     * @param uri     The Uri is checked by functions
-     * @return File path or null if file is missing
-     */
-    public static @Nullable
-    String getFileProviderPath(@NonNull final Context context,
-                               @NonNull final Uri uri) {
-        final File appDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-        final File file = new File(appDir, uri.getLastPathSegment());
-        return file.exists() ? file.toString() : null;
-    }
+	/**
+	 * @param context The Application context
+	 * @param uri     The Uri is checked by functions
+	 * @return File path or null if file is missing
+	 */
+	public static @Nullable
+	String getFileProviderPath(@NonNull final Context context,
+														 @NonNull final Uri uri, @NonNull String directorytype) {
+		File mediaStorageDir = null;
+		if (directorytype.equalsIgnoreCase(Environment.DIRECTORY_MOVIES)) {
+			mediaStorageDir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES), "SMW_VIDEO");
+		} else {
+			mediaStorageDir = context.getExternalFilesDir(directorytype);
+		}
+		final File file = new File(mediaStorageDir, uri.getLastPathSegment());
+		return file.exists() ? file.toString() : null;
+	}
 }


### PR DESCRIPTION
Handled this crash which was occuring 

```
Caused by: java.lang.NullPointerException: 
  at com.imagepicker.utils.RealPathUtil.getRealPathFromURI (RealPathUtil.java:92)
  at com.imagepicker.ImagePickerModule.getRealPathFromURI (ImagePickerModule.java:685)
  at com.imagepicker.ImagePickerModule.onActivityResult (ImagePickerModule.java:448)
  at com.facebook.react.bridge.ReactContext.onActivityResult (ReactContext.java:275)
  at com.facebook.react.ReactInstanceManager.onActivityResult (ReactInstanceManager.java:703)
  at com.facebook.react.ReactDelegate.onActivityResult (ReactDelegate.java:89)
  at com.facebook.react.ReactActivityDelegate.onActivityResult (ReactActivityDelegate.java:110)
  at com.facebook.react.ReactActivity.onActivityResult (ReactActivity.java:67)
  at com.nextbillion.groww.MainActivity.onActivityResult (MainActivity.java:85)
  at android.app.Activity.dispatchActivityResult (Activity.java:7312)
  at android.app.ActivityThread.deliverResults (ActivityThread.java:4445)
```

Added a simple null check for URI, before invoking uri.getScheme()
