### PR TITLE
Add formatToMP4 Option to convert .MOV to .MP4 in iOS

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -42,8 +42,8 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Options
 
-| option                        | iOS | Android | Info                                                                                                                                                                                                                                                                 |
-| ----------------------------- | --- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| option                          | iOS | Android | Info                                                                                                                                                                                                                                                                 |
+| ------------------------------- | --- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | title                           | OK  | OK      | Specify `null` or empty string to remove the title                                                                                                                                                                                                                   |
 | cancelButtonTitle               | OK  | OK      | Specify `null` or empty string to remove this button                                                                                                                                                                                                                 |
 | takePhotoButtonTitle            | OK  | OK      | Specify `null` or empty string to remove this button                                                                                                                                                                                                                 |
@@ -71,6 +71,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | permissionDenied.text           | -   | OK      | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.                                                                                                                            |
 | permissionDenied.reTryTitle     | -   | OK      | Title of re-try button. By default `re-try`                                                                                                                                                                                                                          |
 | permissionDenied.okTitle        | -   | OK      | Title of ok button. By default `I'm sure`                                                                                                                                                                                                                            |
+| formatToMp4                     | OK  | -       | Videos only, to convert `.mov` to `.mp4`. By default `false`
 
 ## The Response Object
 


### PR DESCRIPTION
When iOS records a video the format is .mov which is not playable in browser and Android devices.
That's why .MOV format has to be converted into .MP4 format.