### PR TITLE
Fixed crash bug when calling launchCamera/launchImageLibrary. (launch…

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -25,13 +25,17 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
     self.callback = callback;
-    [self launchImagePicker:RNImagePickerTargetCamera options:options];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self launchImagePicker:RNImagePickerTargetCamera options:options];
+    });
 }
 
 RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
     self.callback = callback;
-    [self launchImagePicker:RNImagePickerTargetLibrarySingleImage options:options];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self launchImagePicker:RNImagePickerTargetLibrarySingleImage options:options];
+    });
 }
 
 RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)


### PR DESCRIPTION
…ImagePicker needs to be run from the main thread)

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

On Ios 13/xcode 11, calling launchImageLibrary causes crash.

This needs to be done on main thread:

[[UIImagePickerController alloc] init];

What existing problem does the pull request solve?

The app crashes when calling launchImageLibrary/launchCamera from react native side.

## Test Plan (required)

Manual testing. Calling the mentioned methods first thing without the fix crashes the app. With the fix it works...

If you have added code that should be tested, add tests.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
