### PR TITLE
Fix android 10+ public folders access

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -416,7 +416,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
         String realPath = getRealPathFromURI(uri);
         final boolean isUrl = !TextUtils.isEmpty(realPath) &&
                 Patterns.WEB_URL.matcher(realPath).matches();
-        if (realPath == null || isUrl)
+        if (realPath == null || isUrl || Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
         {
           try
           {

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -11,6 +11,7 @@ import android.os.Environment;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.Log;
+import android.os.Build;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.imagepicker.ImagePickerModule;
@@ -46,7 +47,13 @@ public class MediaUtils
                 .toString();
 
         // defaults to Public Pictures Directory
-        File path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        File path;
+
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        } else {
+            path = reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        }
 
         if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")) 
         {


### PR DESCRIPTION
## Motivation

There is a problem in this package where the picker and camera doesn't open as they can't have access to external directory folders, this PR uses scoped folders for android 10+.

## Test Plan

To test it, try to open the camera and shot a photo. For the image picker gallery, try to open it and select a image.
