### PR TITLE
Fix: FileProvider class name conflict during manifest merger

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
   >
     <application>
       <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".ImagePickerProvider"
             android:authorities="${applicationId}.imagepickerprovider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/android/src/main/java/com/imagepicker/ImagePickerProvider.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerProvider.java
@@ -1,0 +1,8 @@
+package com.imagepicker;
+
+import androidx.core.content.FileProvider;
+
+// Two FileProvider class with same name will conflict during manifest merger, so we create a class which inherits from FileProvider with different name.
+// This prevents conflict if library users already have used the default FileProvider class.
+public class ImagePickerProvider extends FileProvider {
+}


### PR DESCRIPTION
Should fix https://github.com/react-native-image-picker/react-native-image-picker/issues/1443#issuecomment-719743390

FYI, fixes just that particular comment, not the issue