### PR TITLE
Remove unnecessary buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
-
 
     defaultConfig {
         minSdkVersion 21


### PR DESCRIPTION
Should fix https://github.com/react-native-image-picker/react-native-image-picker/issues/1458