### PR TITLE
Fix: Android permission check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ If you are allowing user to capture image add `NSCameraUsageDescription` key als
 If you are allowing user to capture video add `NSCameraUsageDescription` add `NSMicrophoneUsageDescription` key also.
 
 ### Android
-
-Add permissions in `AndroidManifest.xml`:
-
-```xml
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-```
+No permissions required (`saveToPhotos` requires permission [check](#note-on-file-storage)).
 
 # API Reference
 
@@ -95,7 +90,7 @@ On android, this library does not ask for users permission. You have to make sur
 
 ## Note on file storage
 
-Image/video captured via camera will be stored in temporary folder so will be deleted any time, so don't expect it to persist. Use `saveToPhotos: true` (default is false) to save the file in the public photos.
+Image/video captured via camera will be stored in temporary folder so will be deleted any time, so don't expect it to persist. Use `saveToPhotos: true` (default is false) to save the file in the public photos. `saveToPhotos` requires WRITE_EXTERNAL_STORAGE permission on Android 28 and below.
 
 ## ErrorCode
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ See [Options](#options) for further information on `options`.
 
 The `callback` will be called with a response object, refer to [The Response Object](#the-response-object).
 
-### Permission Handling on Android
 
-On android, this library does not ask for users permission. You have to make sure WRITE_EXTERNAL_STORAGE permission is obtained before calling the above methods.
 
 ## Options
 
@@ -90,7 +88,7 @@ On android, this library does not ask for users permission. You have to make sur
 
 ## Note on file storage
 
-Image/video captured via camera will be stored in temporary folder so will be deleted any time, so don't expect it to persist. Use `saveToPhotos: true` (default is false) to save the file in the public photos. `saveToPhotos` requires WRITE_EXTERNAL_STORAGE permission on Android 28 and below.
+Image/video captured via camera will be stored in temporary folder so will be deleted any time, so don't expect it to persist. Use `saveToPhotos: true` (default is false) to save the file in the public photos. `saveToPhotos` requires WRITE_EXTERNAL_STORAGE permission on Android 28 and below (You have to obtain the permission, the library does not).
 
 ## ErrorCode
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -3,6 +3,7 @@ package com.imagepicker;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -58,7 +59,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         this.callback = callback;
         this.options = new Options(options);
 
-        if (!hasPermission(currentActivity)) {
+        if (this.options.saveToPhotos && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P && !hasPermission(currentActivity)) {
             callback.invoke(getErrorMap(errPermission, null));
             return;
         }
@@ -96,11 +97,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
 
         this.callback = callback;
         this.options = new Options(options);
-
-        if (!hasPermission(currentActivity)) {
-            callback.invoke(getErrorMap(errPermission, null));
-            return;
-        }
 
         int requestCode;
         Intent libraryIntent;


### PR DESCRIPTION
WRITE_EXTERNAL_STORAGE is not required for all cases. More info https://developer.android.com/training/data-storage