### PR TITLE
fix(typescript): move quality from CameraOptions to ImageLibraryOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,12 @@ export interface ImageLibraryOptions {
   mediaType: MediaType;
   maxWidth?: number;
   maxHeight?: number;
+  quality?: PhotoQuality;
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
 }
 
 export interface CameraOptions extends ImageLibraryOptions {
-  quality?: PhotoQuality;
   saveToPhotos?: boolean;
 }
 


### PR DESCRIPTION
## Motivation (required)

Passing a `quality` option to the `launchImageLibrary` function shows a TypeScript error– since the `quality` option is currently only part of `CameraOptions` and not `ImageLibraryOptions`.

From my testing and usage– it looks like setting `quality: 0.3` when I call `launchImageLibrary` is working as intended. (I just have to add a ts-ignore in my project for now)

Version: `react-native-image-picker@3.0.0-vnext.4`