### PR TITLE
Fix:Uri null error in some cases when video captured from camera

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -167,9 +167,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
 
             case REQUEST_LAUNCH_VIDEO_CAPTURE:
                 if (options.saveToPhotos) {
-                    saveToPublicDirectory(data.getData(), reactContext, "video");
+                    saveToPublicDirectory(cameraCaptureURI, reactContext, "video");
                 }
-                onVideoObtained(data.getData());
+                onVideoObtained(cameraCaptureURI);
                 break;
         }
     }


### PR DESCRIPTION
data.getData() works in my android devices but may be not all android camera applications support it, hence use cameraCaptureURI like we do for image capture.

fixes https://github.com/react-native-image-picker/react-native-image-picker/issues/1497