### PR TITLE
Use callbacks collection to avoid multiple invocations on Android

### DIFF
--- a/android/src/main/java/com/imagepicker/CallbacksCollection.java
+++ b/android/src/main/java/com/imagepicker/CallbacksCollection.java
@@ -1,0 +1,49 @@
+package com.imagepicker;
+
+
+import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
+
+import com.facebook.react.bridge.Callback;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+public class CallbacksCollection {
+    final static  Map<Integer, Pair<Callback, Integer>> callbackMap = new HashMap<>();
+    final static Random random = new Random();
+
+    public static Integer set(@NonNull final Callback cb) {
+        int id = random.nextInt(65535);
+        callbackMap.put(id, Pair.create(cb, 0));
+        return id;
+    }
+
+    public static void invoke(final Integer cbId, Object... args) {
+        if (!callbackMap.containsKey(cbId)) {
+            return;
+        }
+        Pair<Callback, Integer> result = callbackMap.get(cbId);
+        callbackMap.remove(cbId);
+        result.first.invoke(args);
+    }
+
+    public static Pair<Callback, Integer> pop(final Integer cbId) {
+        if (!callbackMap.containsKey(cbId)) {
+            return null;
+        }
+        Pair result = callbackMap.get(cbId);
+        callbackMap.remove(cbId);
+        return result;
+    }
+
+    public static void setCode(final Integer cbId, final Integer code) {
+        if (!callbackMap.containsKey(cbId)) {
+            return;
+        }
+        Pair<Callback, Integer> result = callbackMap.get(cbId);
+        callbackMap.remove(cbId);
+        callbackMap.put(cbId, Pair.create(result.first, code));
+    }
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase. (not sure, seems like it's formatted pretty well)
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

Wondering what do you think about this @ravirajn22.

The [`callback`](https://github.com/react-native-image-picker/react-native-image-picker/blob/main/android/src/main/java/com/imagepicker/ImagePickerModule.java#L30) is shared. When calling `launchImageLibrary` or `launchCamera` frequently, two Activities are getting started and the later invocation overrides `callback` for the former.

As a result, `callback` might be invoked more  than once, triggering 

```
java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.
...
```

Resolves https://github.com/react-native-image-picker/react-native-image-picker/issues/713

Re:  Why one would invoke image picker twice?

Shouldn't happen, but does happen accidentally due to various reason - e.g. RN badly handling guestures, slow devices, badly implemented React Hooks. 

The idea is that the library should be resilient to such kind of mistakes.

## Test Plan (required)

Run `launchCamera` or `launchImageLibrary` one after another, pick / create an image and see the code.