### PR TITLE
Fix: Types path not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "files": [
     "/android",
     "!/android/build",


### PR DESCRIPTION
Fix "Cannot find module 'react-native-image-picker' or its corresponding type declarations."

- [X] Version 3.0.0 path is wrong
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Version 3.0.0 types not found

Fix types path to react-native-image-picker
