### PR TITLE
Change directory where temporary files are stored to cache directory

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -159,7 +159,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
                 break;
 
             case REQUEST_LAUNCH_IMAGE_LIBRARY:
-                onImageObtained(data.getData());
+                onImageObtained(getAppSpecificStorageUri(data.getData(), reactContext));
                 break;
 
             case REQUEST_LAUNCH_VIDEO_LIBRARY:

--- a/android/src/main/res/xml/imagepicker_provider_paths.xml
+++ b/android/src/main/res/xml/imagepicker_provider_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-  <external-path name="external" path="." />
+  <cache-path name="cacheDir" path="." />
 </paths>


### PR DESCRIPTION
Now we don't delete files on every call, instead it will be handled by
Android OS. So people can expect to save the Uri and use it in later
session unless android clears the cache.

Make a copy of image file picked from gallery into internal storage for
later access. We don't copy videos picked from android gallery, so the uri 
wont persist sessions.

Now the implementation is same in iOS and Android, except for handling
of videos in android where videos picked from gallery are not duplicated. Which needs further discussion.
