### PR TITLE
fix: [iOS] Build failed with error: Undefined symbols for architectur…

### DIFF
--- a/ios/RNImagePicker.xcodeproj/project.pbxproj
+++ b/ios/RNImagePicker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		014A3B6A1C6CF34500B6D375 /* ImagePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 014A3B691C6CF34500B6D375 /* ImagePickerManager.m */; };
+		3CAFA04725A83F4500C5B8F3 /* ImagePickerUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = C1D0CF212509FD5E00304E19 /* ImagePickerUtils.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -117,6 +118,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3CAFA04725A83F4500C5B8F3 /* ImagePickerUtils.m in Sources */,
 				014A3B6A1C6CF34500B6D375 /* ImagePickerManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
…e x86_64 (#1558)

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

This pull request solved the problem: Build failed when link library manually on iOS with RN <0.60. This bug cause by missing ImagePickerUtils.m in Compile Source.

## Test Plan (required)

I have test this carefully on my project and see no problem with it.
