### PR TITLE
fix: wrong types path (#1554)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
   "main": "src/index.ts",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "files": [
     "/android",
     "!/android/build",


### PR DESCRIPTION
Fix for Cannot find module 'react-native-image-picker' or its corresponding type declarations. #1554

## Motivation (required)

What existing problem does the pull request solve?

This fixes the issue 'Cannot find module 'react-native-image-picker' or its corresponding type declarations.' #1554 

## Test Plan (required)

Tested fine after changing `types` path.
