### PR TITLE
Show error and return when there is no callback function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ const DEFAULT_OPTIONS: CameraOptions = {
 };
 
 export function launchCamera(options: CameraOptions, callback: Callback) {
+  if (typeof callback !== 'function') {
+    console.error("Send proper callback function, check API");
+    return;
+  }
+
   NativeModules.ImagePickerManager.launchCamera(
     {...DEFAULT_OPTIONS, ...options},
     callback,
@@ -25,6 +30,10 @@ export function launchImageLibrary(
   options: ImageLibraryOptions,
   callback: Callback,
 ) {
+  if (typeof callback !== 'function') {
+    console.error("Send proper callback function, check API");
+    return;
+  }
   NativeModules.ImagePickerManager.launchImageLibrary(
     {...DEFAULT_OPTIONS, ...options},
     callback,


### PR DESCRIPTION
The library exits quietly logging error only on the native side when there is no callback function.
Like the issue https://github.com/react-native-image-picker/react-native-image-picker/issues/1589

Showing proper errors then and there should help library users self diagnose and fix error, instead of opening an issue.

