### PR TITLE
[iOS] get access to the original photo path and name

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -98,10 +98,17 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
 - (void)onImageObtained:(NSDictionary<NSString *,id> *)info {
 
+
+    NSURL *imagePath = [info objectForKey:UIImagePickerControllerReferenceURL];
+    NSString *originalImagePath = imagePath.absoluteString;
+    PHFetchResult *result = [PHAsset fetchAssetsWithALAssetURLs:@[originalImagePath] options:nil];
+    NSString *originalFileName = [[result firstObject] filename];
+
     NSURL *imageURL = [ImagePickerManager getNSURLFromInfo:info];
     self.response = [[NSMutableDictionary alloc] init];
     UIImage *image = [ImagePickerManager getUIImageFromInfo:info];
     NSData *data;
+
 
     if ((target == camera) && [self.options[@"saveToPhotos"] boolValue]) {
         UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
@@ -142,6 +149,8 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
 
     self.response[@"fileName"] = fileName;
+    self.response[@"originalFileName"] = originalFileName;
+    self.response[@"originalImagePath"] = originalImagePath;
     self.response[@"width"] = @(image.size.width);
     self.response[@"height"] = @(image.size.height);
     self.callback(@[self.response]);

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -101,7 +101,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
     NSURL *imagePath = [info objectForKey:UIImagePickerControllerReferenceURL];
     NSString *originalImagePath = imagePath.absoluteString;
-    PHFetchResult *result = [PHAsset fetchAssetsWithALAssetURLs:@[originalImagePath] options:nil];
+    PHFetchResult *result = [PHAsset fetchAssetsWithALAssetURLs:@[imagePath] options:nil];
     NSString *originalFileName = [[result firstObject] filename];
 
     NSURL *imageURL = [ImagePickerManager getNSURLFromInfo:info];

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -102,7 +102,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     NSURL *imagePath = [info objectForKey:UIImagePickerControllerReferenceURL];
     NSString *originalImagePath = imagePath.absoluteString;
     PHFetchResult *result = [PHAsset fetchAssetsWithALAssetURLs:@[imagePath] options:nil];
-    NSString *originalFileName = [[result firstObject] filename];
+    NSString *originalImageName = [[result firstObject] filename];
 
     NSURL *imageURL = [ImagePickerManager getNSURLFromInfo:info];
     self.response = [[NSMutableDictionary alloc] init];
@@ -149,7 +149,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
 
     self.response[@"fileName"] = fileName;
-    self.response[@"originalFileName"] = originalFileName;
+    self.response[@"originalImageName"] = originalImageName;
     self.response[@"originalImagePath"] = originalImagePath;
     self.response[@"width"] = @(image.size.width);
     self.response[@"height"] = @(image.size.height);

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface ImagePickerResponse {
   type?: string; //TODO
   fileName?: string;
   //IOS ONLY original image is the image reduced to 2038x2048
-  originalFileName?: string;
+  originalImageName?: string;
   originalImagePath?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,9 @@ export interface ImagePickerResponse {
   fileSize?: number;
   type?: string; //TODO
   fileName?: string;
+  //IOS ONLY original image is the image reduced to 2038x2048
+  originalFileName?: string;
+  originalImagePath?: string;
 }
 
 export type PhotoQuality =


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation 

On iOS photos in the picker are limited to 2048x2048px
You may need the photo in full resolution (which may be higher) for instance for doing Image Processing algorithms on it and in my case upload it to a remote server.

This PR add 2 fields in the response object : 
```typescript
 //only for iOS
 originalImageName?: string;
 originalImagePath?: string;
 ```

What existing problem does the pull request solve?

## Test Plan - Demo

### upload large image 
<img width="395" alt="Capture d’écran 2021-01-26 à 14 04 57" src="https://user-images.githubusercontent.com/9252579/105849771-1f291b00-5fe1-11eb-8121-e9ab9b1d50a2.png">

### get the original asset (for uploading it to a remote server)
<img width="1044" alt="Capture d’écran 2021-01-26 à 14 14 09" src="https://user-images.githubusercontent.com/9252579/105849946-5d263f00-5fe1-11eb-88e3-0f5109222a48.png">





