### PR TITLE
Refactor how image picker intent is created

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -114,7 +114,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
             libraryIntent.setType("video/*");
         } else {
             requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
-            libraryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+            libraryIntent = new Intent(Intent.ACTION_PICK);
+            libraryIntent.setType("image/*");
         }
 
         if (libraryIntent.resolveActivity(reactContext.getPackageManager()) == null) {


### PR DESCRIPTION
Set type for intent instead of using URI to select image picker application. Now video and image picker intent uses same technique.

Should also fix #1613 (I still don't know if its valid error since I was not able to reproduce)