### PR TITLE
fix: add the correct permissions to the camera intent

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -86,6 +86,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
             cameraCaptureURI = createUri(createFile(reactContext, "jpg"), reactContext);
         }
         cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, cameraCaptureURI);
+        cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
         if (cameraIntent.resolveActivity(reactContext.getPackageManager()) == null) {
             callback.invoke(getErrorMap(errOthers, "Activity error"));


### PR DESCRIPTION
Best practice is to give read and write permission to content uri before sending to other apps.