### PR TITLE
docs(readme): updated iOS Response object fileName property

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | height       | OK  | OK      | Image dimensions (photos only)                                                                                  |
 | fileSize     | OK  | OK      | The file size (photos only)                                                                                     |
 | type         | OK  | OK      | The file type (photos only)                                                                                     |
-| fileName     | OK  | OK      | The file name                                                                                                   |
+| fileName     | OK  | OK      | The file name (not available on iOS videos)                                                                     |
 
 ## Note on file storage
 


### PR DESCRIPTION
## Motivation

I ran into issue with fileName being undefined on iOS on videos when tried to parse it
fileName property is available only for Android photos/videos and photos in iOS, on iOS video fileName is undefined.


## Test Plan

This is only README update so I don't think any test plan is needed
