### PR TITLE
feat: add prop "copyTo" to have a copy of the file in cache folder or document folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | cameraType    | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                    |
 | includeBase64 | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance) |
 | saveToPhotos  | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo              |
+| copyTo  | OK  | OK      | 'cachesDirectory' or 'documentDirectory'. Also saves the image/video file captured to cache/document directory              |
 
 ## The Response Object
 
@@ -106,6 +107,8 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | type         | OK  | OK      | The file type (photos only)                                                                                     |
 | fileName     | OK  | OK      | The file name                                                                                                   |
 | duration     | OK  | OK      | The selected video duration in seconds                                                                          |
+| fileCopyUri     | OK  | OK      | The uri of the copied file. If 'copyTo' is not specified, it's the same as 'uri'                                                                           |
+| copyError     | OK  | OK      | Error description if file copy failed                                                                          |
 
 ## Note on file storage
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -146,7 +146,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
     }
 
     void onVideoObtained(Uri uri) {
-        callback.invoke(getVideoResponseMap(uri, reactContext));
+        callback.invoke(getVideoResponseMap(uri, options, reactContext));
     }
 
     @Override

--- a/android/src/main/java/com/imagepicker/Options.java
+++ b/android/src/main/java/com/imagepicker/Options.java
@@ -13,6 +13,7 @@ public class Options {
     Boolean saveToPhotos;
     int durationLimit;
     Boolean useFrontCamera = false;
+    String copyTo;
 
 
     Options(ReadableMap options) {
@@ -35,5 +36,6 @@ public class Options {
         maxWidth = options.getInt("maxWidth");
         saveToPhotos = options.getBoolean("saveToPhotos");
         durationLimit = options.getInt("durationLimit");
+        copyTo = options.getString("copyTo");
     }
 }

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -341,6 +341,7 @@ public class Utils {
 
         WritableMap map = Arguments.createMap();
         map.putString("uri", uri.toString());
+        map.putString("fileCopyUri", uri.toString());
         map.putDouble("fileSize", getFileSize(uri, context));
         map.putString("fileName", fileName);
         map.putString("type", getMimeTypeFromFileUri(uri));
@@ -357,6 +358,7 @@ public class Utils {
         String fileName = uri.getLastPathSegment();
         WritableMap map = Arguments.createMap();
         map.putString("uri", uri.toString());
+        map.putString("fileCopyUri", uri.toString());
         map.putDouble("fileSize", getFileSize(uri, context));
         map.putInt("duration", getDuration(uri, context));
         map.putString("fileName", fileName);

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -198,6 +198,16 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     AVAsset *asset = [AVAsset assetWithURL:videoDestinationURL];
     self.response[@"duration"] = @(roundf(CMTimeGetSeconds(asset.duration)));
     self.response[@"uri"] = videoDestinationURL.absoluteString;
+    
+    NSError *copyError;
+    NSString *copyDestination = self.options[@"copyTo"] ? self.options[@"copyTo"] : nil;
+    NSURL* maybeFileCopyPath = copyDestination ? [ImagePickerManager copyToUniqueDestinationFrom:videoDestinationURL usingDestinationPreset:copyDestination error:copyError] : videoDestinationURL;
+    self.response[@"fileCopyUri"] =  maybeFileCopyPath.absoluteString;
+            
+    if (copyError) {
+        self.response[@"copyError"] = copyError.description;
+    }
+    
     self.callback(@[self.response]);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface ImageLibraryOptions {
   quality?: PhotoQuality;
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
+  copyTo?: 'cachesDirectory' | 'documentDirectory';
 }
 
 export interface CameraOptions extends ImageLibraryOptions {
@@ -21,6 +22,8 @@ export interface ImagePickerResponse {
   errorMessage?: string;
   base64?: string;
   uri?: string;
+  fileCopyUri?: string;
+  copyError?: string;
   width?: number;
   height?: number;
   fileSize?: number;


### PR DESCRIPTION

## Motivation (required)

Hi, I added the prop 'copyTo', similar as how it's done in [this library](https://github.com/rnmods/react-native-document-picker), to allow the user to store the photo/video in the cache directory or document directory. 
This because, using the tmp directory in iOS, I had a problem where the files got deleted from the directory before I could actually upload them to the server. 
If copyTo is specified, the copied file uri is returned in the response as ‘fileCopyUri’, otherwise this field just contains the same original uri.


## Test Plan (required)

I tested with the picker on ios and android.
