### PR TITLE
Make REQUEST_LAUNCH codes public

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -22,7 +22,8 @@ import static com.imagepicker.Utils.*;
 @ReactModule(name = ImagePickerModule.NAME)
 public class ImagePickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
     static final String NAME = "ImagePickerManager";
-    
+
+    // Public to let consuming apps hook into the image picker response
     public static final int REQUEST_LAUNCH_IMAGE_CAPTURE = 13001;
     public static final int REQUEST_LAUNCH_VIDEO_CAPTURE = 13002;
     public static final int REQUEST_LAUNCH_LIBRARY = 13003;

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -23,10 +23,10 @@ import static com.imagepicker.Utils.*;
 public class ImagePickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
     static final String NAME = "ImagePickerManager";
 
-    static final int REQUEST_LAUNCH_IMAGE_CAPTURE = 13001;
-    static final int REQUEST_LAUNCH_IMAGE_LIBRARY = 13002;
-    static final int REQUEST_LAUNCH_VIDEO_LIBRARY = 13003;
-    static final int REQUEST_LAUNCH_VIDEO_CAPTURE = 13004;
+    public static final int REQUEST_LAUNCH_IMAGE_CAPTURE = 13001;
+    public static final int REQUEST_LAUNCH_IMAGE_LIBRARY = 13002;
+    public static final int REQUEST_LAUNCH_VIDEO_LIBRARY = 13003;
+    public static final int REQUEST_LAUNCH_VIDEO_CAPTURE = 13004;
 
     private Uri fileUri;
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Thanks in advance for taking a look. The product I work on uses react-native-image-picker. We would like to hook directly into these REQUEST_LAUNCH codes, but newer versions of this package don't expose them publicly anymore. I looked at the change that took them from public to private, and there didn't seem to be an explicit reason for the change. This change just makes them public again.

## Test Plan (required)

Just a minor change to make it easier for consuming apps to use these codes. Just making the 4 codes public.