### PR TITLE
fix: image orientation on android

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
 import android.hardware.camera2.CameraCharacteristics;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
@@ -203,11 +204,12 @@ public class Utils {
             Bitmap b = BitmapFactory.decodeStream(imageStream);
             b = Bitmap.createScaledBitmap(b, newDimens[0], newDimens[1], true);
             String originalOrientation = getOrientation(uri, context);
+            int orientation = originalOrientation != null ? Integer.parseInt(originalOrientation) :  ExifInterface.ORIENTATION_NORMAL;
+            b = getRotatedImage(b, orientation);
 
             File file = createFile(context, getFileTypeFromMime(mimeType));
             OutputStream os = context.getContentResolver().openOutputStream(Uri.fromFile(file));
             b.compress(getBitmapCompressFormat(mimeType), options.quality, os);
-            setOrientation(file, originalOrientation, context);
             return Uri.fromFile(file);
 
         } catch (Exception e) {
@@ -221,14 +223,27 @@ public class Utils {
         return exifInterface.getAttribute(ExifInterface.TAG_ORIENTATION);
     }
 
-    // ExifInterface.saveAttributes is costly operation so don't set exif for unnecessary orientations
-    static void setOrientation(File file, String orientation, Context context) throws IOException {
-        if (orientation.equals(String.valueOf(ExifInterface.ORIENTATION_NORMAL)) || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_UNDEFINED))) {
-            return;
+    static Bitmap getRotatedImage(Bitmap bitmap, int orientation) throws IOException {
+        if (orientation == ExifInterface.ORIENTATION_NORMAL) {
+            return bitmap;
         }
-        ExifInterface exifInterface = new ExifInterface(file);
-        exifInterface.setAttribute(ExifInterface.TAG_ORIENTATION, orientation);
-        exifInterface.saveAttributes();
+
+        int rotationAngle;
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_90: rotationAngle = 90; break;
+            case ExifInterface.ORIENTATION_ROTATE_180: rotationAngle = 180; break;
+            case ExifInterface.ORIENTATION_ROTATE_270: rotationAngle = 270; break;
+            default: rotationAngle = 0;
+        }
+
+        if (rotationAngle == 0) return bitmap;
+
+        int width = bitmap.getWidth();
+        int height = bitmap.getHeight();
+
+        Matrix matrix = new Matrix();
+        matrix.setRotate(rotationAngle, (float) width / 2, (float) height / 2);
+        return Bitmap.createBitmap(bitmap, 0, 0, width, height, matrix, true);
     }
 
     static int[] getImageDimensBasedOnConstraints(int origWidth, int origHeight, Options options) {
@@ -388,7 +403,7 @@ public class Utils {
         int[] dimensions = getImageDimensions(uri, context);
 
         WritableMap map = Arguments.createMap();
-        map.putString("uri", uri.toString());
+        map.putString("uri", resizeImage(uri, context, options).toString());
         map.putDouble("fileSize", getFileSize(uri, context));
         map.putString("fileName", fileName);
         map.putString("type", getMimeTypeFromFileUri(uri));

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -403,7 +403,7 @@ public class Utils {
         int[] dimensions = getImageDimensions(uri, context);
 
         WritableMap map = Arguments.createMap();
-        map.putString("uri", resizeImage(uri, context, options).toString());
+        map.putString("uri", uri.toString());
         map.putDouble("fileSize", getFileSize(uri, context));
         map.putString("fileName", fileName);
         map.putString("type", getMimeTypeFromFileUri(uri));


### PR DESCRIPTION
## Motivation

Fix camera image's orientation issue on android [#1701](https://github.com/react-native-image-picker/react-native-image-picker/issues/1701)

Inspired by [stack overflow](https://stackoverflow.com/a/14066265)

## Test Plan

Use `launchCamera` to take photo, the assets returned should display correctly on Image Component.
Tested on Pixel 4a (android 12).
