### PR TITLE
fix: App crashed after select Video from Library in iOS 13 (#1742)

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -248,7 +248,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             [fileManager copyItemAtURL:url toURL:videoDestinationURL error:error];
           }
 
-          if (*error) {
+          if (error && *error) {
               return nil;
           }
         }

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -93,7 +93,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             [assets addObject:[self mapImageToAsset:image data:[NSData dataWithContentsOfURL:[ImagePickerManager getNSURLFromInfo:info]]]];
         } else {
             NSError *error;
-            NSDictionary *asset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] error:nil];
+            NSDictionary *asset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] error:&error];
             if (asset == nil) {
                 self.callback(@[@{@"errorCode": errOthers, @"errorMessage":  error.localizedFailureReason}]);
                 return;
@@ -241,15 +241,15 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         }
 
         if (url) { // Protect against reported crash
-            NSError * err = nil;
+            NSError * error;
           // If we have write access to the source file, move it. Otherwise use copy.
           if ([fileManager isWritableFileAtPath:[url path]]) {
-            [fileManager moveItemAtURL:url toURL:videoDestinationURL error:&err];
+            [fileManager moveItemAtURL:url toURL:videoDestinationURL error:&error];
           } else {
-            [fileManager copyItemAtURL:url toURL:videoDestinationURL error:&err];
+            [fileManager copyItemAtURL:url toURL:videoDestinationURL error:&error];
           }
 
-          if (err) {
+          if (error) {
               return nil;
           }
         }

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -93,7 +93,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             [assets addObject:[self mapImageToAsset:image data:[NSData dataWithContentsOfURL:[ImagePickerManager getNSURLFromInfo:info]]]];
         } else {
             NSError *error;
-            NSDictionary *asset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] error:&error];
+            NSDictionary *asset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] error:nil];
             if (asset == nil) {
                 self.callback(@[@{@"errorCode": errOthers, @"errorMessage":  error.localizedFailureReason}]);
                 return;
@@ -241,15 +241,15 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         }
 
         if (url) { // Protect against reported crash
-
+            NSError * err = nil;
           // If we have write access to the source file, move it. Otherwise use copy.
           if ([fileManager isWritableFileAtPath:[url path]]) {
-            [fileManager moveItemAtURL:url toURL:videoDestinationURL error:error];
+            [fileManager moveItemAtURL:url toURL:videoDestinationURL error:&err];
           } else {
-            [fileManager copyItemAtURL:url toURL:videoDestinationURL error:error];
+            [fileManager copyItemAtURL:url toURL:videoDestinationURL error:&err];
           }
 
-          if (error) {
+          if (err) {
               return nil;
           }
         }

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -241,15 +241,14 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         }
 
         if (url) { // Protect against reported crash
-            NSError * error;
           // If we have write access to the source file, move it. Otherwise use copy.
           if ([fileManager isWritableFileAtPath:[url path]]) {
-            [fileManager moveItemAtURL:url toURL:videoDestinationURL error:&error];
+            [fileManager moveItemAtURL:url toURL:videoDestinationURL error:error];
           } else {
-            [fileManager copyItemAtURL:url toURL:videoDestinationURL error:&error];
+            [fileManager copyItemAtURL:url toURL:videoDestinationURL error:error];
           }
 
-          if (error) {
+          if (*error) {
               return nil;
           }
         }


### PR DESCRIPTION
## Motivation

Fix issue for App crashed after select Video from Library in iOS 13. #1742 

I made the code changes by referring to react-native-image-picker v2.3.4
- Create a new object `NSError * err = nil;` to replace error checking in `mapVideoToAsset`
- The new `err` will use to detect error returned from `([fileManager isWritableFileAtPath:[url path]])`

## Test Plan
1. Use iOS 13 device to open react-native-image-picker.
2. Select Video from image picker.
3. Should able to get video without crashing.