### PR TITLE
fix: HEIC image issue for ios

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -99,7 +99,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 #pragma mark - Helpers
 
 -(NSMutableDictionary *)mapImageToAsset:(UIImage *)image data:(NSData *)data {
-    NSString *fileType = [ImagePickerUtils getFileType:data];
+    NSString *fileType = [ImagePickerUtils getFileType:data isCamera:target == camera];
     
     if ((target == camera) && [self.options[@"saveToPhotos"] boolValue]) {
         UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);

--- a/ios/ImagePickerUtils.h
+++ b/ios/ImagePickerUtils.h
@@ -10,8 +10,8 @@
 
 + (PHPickerConfiguration *)makeConfigurationFromOptions:(NSDictionary *)options target:(RNImagePickerTarget)target API_AVAILABLE(ios(14));
 
-+ (NSString*)getFileType:(NSData*)imageData;
++ (NSString *)getFileType:(NSData *)imageData isCamera:(Boolean)isCamera;
 
-+ (UIImage*)resizeImage:(UIImage*)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight;
++ (UIImage *)resizeImage:(UIImage *)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight;
     
 @end

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -80,7 +80,8 @@
     const uint8_t firstByteJpg = 0xFF;
     const uint8_t firstBytePng = 0x89;
     const uint8_t firstByteGif = 0x47;
-    
+    const uint8_t firstByteHeic = 0x00;
+
     uint8_t firstByte;
     [imageData getBytes:&firstByte length:1];
     switch (firstByte) {
@@ -90,6 +91,13 @@
         return @"png";
       case firstByteGif:
         return @"gif";
+      case firstByteHeic:
+        if(isCamera) {
+          return @"jpg";
+        }
+        else {
+          return @"heic";
+        }
       default:
         return @"jpg";
     }


### PR DESCRIPTION
Credit goes to  @nomi9995, I'm just fixing a formatting issue.

From @nomi9995:

> Motivation (required)
when we choose the HEIC image from the library then this library makes the image in tmp directory but in HEIC it is not making an image in tmp directory. I added support for HEIC image

> fixed #872 & #890

> Test Plan (required)
I have tested this on my phone. There are no automated tests in the repo.
you can choose HEIC image from the library then you will see the HEIC image is making in tmp directory