### PR TITLE
docs: update docs for HEIC image for simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Image/video captured via camera will be stored in temporary folder so will be de
 | permission         | Permission not satisfied                          |
 | others             | other errors (check errorMessage for description) |
 
+## Known issues
+
+### iOS
+**HEIC:** Starting with version **0.8.1** the iOS implementation uses PHPicker to pick (multiple) images on iOS 14 or higher.
+As a result of implementing PHPicker it becomes impossible to pick HEIC images on the iOS **simulator** in iOS 14+. This is a known issue. Please test this on a real device, or test with non-HEIC images until Apple solves this issue.[63426347 - Apple known issue](https://www.google.com/search?q=63426347+apple&sxsrf=ALeKk01YnTMid5S0PYvhL8GbgXJ40ZS[…]t=gws-wiz&ved=0ahUKEwjKh8XH_5HwAhWL_rsIHUmHDN8Q4dUDCA8&uact=5)
+
 ## License
 
 [MIT](LICENSE.md)


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

when we choose the `HEIC` image from the library then this library makes the image in tmp directory but in `HEIC` it is not making an image in tmp directory but I have learned it does not work only on the simulator

#1762 and #1787 were hacky solutions therefore we should not merge those PR.

#872 & #890

## Test Plan (required)

I have tested this on my phone. There are no automated tests in the repo.
when you will choose HEIC image from simulator then it will not work but if you will choose HEIC image from device then it will work

