### PR TITLE
Added ability to include exif data for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A React Native module that allows you to select a photo/video from the device li
 </p>
 
 ### Make sure you're reading the doc applicable to your version, for example if your using version 3.8.0 go to tag 3.8.0 and read those docs. This doc is always that of main branch.
-### Also read version release notes for any breaking changes especially if you're updating the major version.
 
+### Also read version release notes for any breaking changes especially if you're updating the major version.
 
 # Install
 
@@ -66,7 +66,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 Launch gallery to pick image or video.
 
 ```js
-launchImageLibrary(options?, callback)
+launchImageLibrary(options?, callback);
 ```
 
 See [Options](#options) for further information on `options`.
@@ -75,40 +75,42 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Options
 
-| Option        | iOS | Android | Description                                                                                           |
-| ------------- | --- | ------- | ----------------------------------------------------------------------------------------------------- |
-| mediaType     | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video) |
-| maxWidth      | OK  | OK      | To resize the image                                                                                   |
-| maxHeight     | OK  | OK      | To resize the image                                                                                   |
-| videoQuality  | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                         |
-| durationLimit | OK  | OK      | Video max duration in seconds                                                                         |
-| quality       | OK  | OK      | 0 to 1, photos                                                                                        |
-| cameraType    | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                        |
-| includeBase64 | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)     |
-| saveToPhotos  | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                  |
-| selectionLimit| OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value|
+| Option         | iOS | Android | Description                                                                                                                               |
+| -------------- | --- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| mediaType      | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video)                                     |
+| maxWidth       | OK  | OK      | To resize the image                                                                                                                       |
+| maxHeight      | OK  | OK      | To resize the image                                                                                                                       |
+| videoQuality   | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                             |
+| durationLimit  | OK  | OK      | Video max duration in seconds                                                                                                             |
+| quality        | OK  | OK      | 0 to 1, photos                                                                                                                            |
+| cameraType     | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                            |
+| includeBase64  | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image                                                                   |
+| includeExif    | OK  | OK      | If true, will include exif data. Library permissions are required for this option                                                         |
+| saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
+| selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
 
 ## The Response Object
 
-| key                         | iOS | Android | Description                                             |
-| --------------------------- | --- | ------- | ------------------------------------------------------- |
-| didCancel                   | OK  | OK      | `true` if the user cancelled the process                |
-| errorCode                   | OK  | OK      | Check [ErrorCode](#ErrorCode) for all error codes       |
-| errorMessage                | OK  | OK      | Description of the error, use it for debug purpose only |
-| assets                      | OK  | OK      | Array of the selected media, [refer to Asset Object](#Asset-Object) |
+| key          | iOS | Android | Description                                                         |
+| ------------ | --- | ------- | ------------------------------------------------------------------- |
+| didCancel    | OK  | OK      | `true` if the user cancelled the process                            |
+| errorCode    | OK  | OK      | Check [ErrorCode](#ErrorCode) for all error codes                   |
+| errorMessage | OK  | OK      | Description of the error, use it for debug purpose only             |
+| assets       | OK  | OK      | Array of the selected media, [refer to Asset Object](#Asset-Object) |
 
 ## Asset Object
 
-| key      | iOS | Android | Description                                                                                                                                                                                                                                |
-| -------- | --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| base64   | OK  | OK      | The base64 string of the image (photos only)                                                                                                                                                                                               |
-| uri      | OK  | OK      | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
-| width    | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
-| height   | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
-| fileSize | OK  | OK      | The file size (photos only)                                                                                                                                                                                                                |
-| type     | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
-| fileName | OK  | OK      | The file name                                                                                                                                                                                                                              |
-| duration | OK  | OK      | The selected video duration in seconds                                                                                                                                                                                                     |
+| key       | iOS | Android | Description                                                                                                                                                                                                                                |
+| --------- | --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| base64    | OK  | OK      | The base64 string of the image (photos only)                                                                                                                                                                                               |
+| uri       | OK  | OK      | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
+| width     | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
+| height    | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
+| fileSize  | OK  | OK      | The file size (photos only)                                                                                                                                                                                                                |
+| type      | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
+| fileName  | OK  | OK      | The file name                                                                                                                                                                                                                              |
+| duration  | OK  | OK      | The selected video duration in seconds                                                                                                                                                                                                     |
+| timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExif' is true                                                                                                                                                                             |
 
 ## Note on file storage
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | quality        | OK  | OK      | 0 to 1, photos                                                                                                                            |
 | cameraType     | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                            |
 | includeBase64  | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image                                                                   |
-| includeExif    | OK  | OK      | If true, will include exif data. Library permissions are required for this option                                                         |
+| includeExtra   | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                      |
 | saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
 | selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
 
@@ -110,7 +110,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | type      | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
 | fileName  | OK  | OK      | The file name                                                                                                                                                                                                                              |
 | duration  | OK  | OK      | The selected video duration in seconds                                                                                                                                                                                                     |
-| timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExif' is true                                                                                                                                                                             |
+| timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExtra' is true                                                                                                                                                                            |
 
 ## Note on file storage
 

--- a/android/src/main/java/com/imagepicker/Options.java
+++ b/android/src/main/java/com/imagepicker/Options.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 public class Options {
     int selectionLimit;
     Boolean includeBase64;
+    Boolean includeExif;
     int videoQuality = 1;
     int quality;
     int maxWidth;
@@ -20,6 +21,7 @@ public class Options {
         mediaType = options.getString("mediaType");
         selectionLimit = options.getInt("selectionLimit");
         includeBase64 = options.getBoolean("includeBase64");
+        includeExif = options.getBoolean("includeExif");
 
         String videoQualityString = options.getString("videoQuality");
         if(!TextUtils.isEmpty(videoQualityString) && !videoQualityString.toLowerCase().equals("high")) {

--- a/android/src/main/java/com/imagepicker/Options.java
+++ b/android/src/main/java/com/imagepicker/Options.java
@@ -6,7 +6,7 @@ import android.text.TextUtils;
 public class Options {
     int selectionLimit;
     Boolean includeBase64;
-    Boolean includeExif;
+    Boolean includeExtra;
     int videoQuality = 1;
     int quality;
     int maxWidth;
@@ -21,7 +21,7 @@ public class Options {
         mediaType = options.getString("mediaType");
         selectionLimit = options.getInt("selectionLimit");
         includeBase64 = options.getBoolean("includeBase64");
-        includeExif = options.getBoolean("includeExif");
+        includeExtra = options.getBoolean("includeExtra");
 
         String videoQualityString = options.getString("videoQuality");
         if(!TextUtils.isEmpty(videoQualityString) && !videoQualityString.toLowerCase().equals("high")) {

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -399,6 +399,19 @@ public class Utils {
         if (options.includeBase64) {
             map.putString("base64", getBase64String(uri, context));
         }
+
+        if(options.includeExif) {
+          try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
+            ExifInterface exif = new ExifInterface(inputStream);
+            String datetime =  exif.getAttribute(ExifInterface.TAG_DATETIME);
+            // Add more exif data here ...
+
+            map.putString("timestamp", datetime);
+          } catch (Exception e) {
+            Log.e("RNIP", "Could not load image exif data: " + e.getMessage());
+          }
+        }
+
         return map;
     }
 

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -37,10 +37,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import static com.imagepicker.ImagePickerModule.*;
@@ -404,10 +407,14 @@ public class Utils {
         if(options.includeExtra) {
           try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
             ExifInterface exif = new ExifInterface(inputStream);
-            String datetime =  exif.getAttribute(ExifInterface.TAG_DATETIME);
+            Date datetime = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss").parse(exif.getAttribute(ExifInterface.TAG_DATETIME));
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+            String datetimeAsString =  formatter.format(datetime);
+
             // Add more exif data here ...
 
-            map.putString("timestamp", datetime);
+            map.putString("timestamp", datetimeAsString);
           } catch (Exception e) {
             Log.e("RNIP", "Could not load image exif data: " + e.getMessage());
           }

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -19,6 +19,7 @@ import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import android.util.Base64;
+import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import androidx.core.app.ActivityCompat;

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -401,7 +401,7 @@ public class Utils {
             map.putString("base64", getBase64String(uri, context));
         }
 
-        if(options.includeExif) {
+        if(options.includeExtra) {
           try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
             ExifInterface exif = new ExifInterface(inputStream);
             String datetime =  exif.getAttribute(ExifInterface.TAG_DATETIME);

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -159,7 +159,8 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     
     if(phAsset){
         NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+        [formatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
         NSString *creationDate = [formatter stringFromDate:phAsset.creationDate];
         
         asset[@"timestamp"] = creationDate;

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -69,7 +69,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             picker.delegate = self;
             picker.presentationController.delegate = self;
 
-            if([self.options[@"includeExif"] boolValue]) {
+            if([self.options[@"includeExtra"] boolValue]) {
                 
                 [self checkPhotosPermissions:^(BOOL granted) {
                     if (!granted) {
@@ -90,7 +90,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     [ImagePickerUtils setupPickerFromOptions:picker options:self.options target:target];
     picker.delegate = self;
     
-    if([self.options[@"includeExif"] boolValue]) {
+    if([self.options[@"includeExtra"] boolValue]) {
         [self checkPhotosPermissions:^(BOOL granted) {
             if (!granted) {
                 self.callback(@[@{@"errorCode": errPermission}]);
@@ -333,7 +333,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             UIImage *image = [ImagePickerManager getUIImageFromInfo:info];
             
             // If include exif, we fetch the PHAsset, this required library permissions
-            if([self.options[@"includeExif"] boolValue]) {
+            if([self.options[@"includeExtra"] boolValue]) {
                 NSURL *referenceURL = [info objectForKey:UIImagePickerControllerReferenceURL];
                 
                 if(referenceURL != nil) {
@@ -407,7 +407,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         NSItemProvider *provider = result.itemProvider;
 
         // If include exif, we fetch the PHAsset, this required library permissions
-        if([self.options[@"includeExif"] boolValue] && result.assetIdentifier != nil) {
+        if([self.options[@"includeExtra"] boolValue] && result.assetIdentifier != nil) {
             PHFetchResult* fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[result.assetIdentifier] options:nil];
             asset = fetchResult.firstObject;
         }

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -86,18 +86,21 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         }
     }
 #endif
-    
     UIImagePickerController *picker = [[UIImagePickerController alloc] init];
     [ImagePickerUtils setupPickerFromOptions:picker options:self.options target:target];
     picker.delegate = self;
-
-    [self checkPermission:^(BOOL granted) {
-        if (!granted) {
-            self.callback(@[@{@"errorCode": errPermission}]);
-            return;
-        }
-        [self showPickerViewController:picker];
-    }];
+    
+    if([self.options[@"includeExif"] boolValue]) {
+        [self checkPhotosPermissions:^(BOOL granted) {
+            if (!granted) {
+                self.callback(@[@{@"errorCode": errPermission}]);
+                return;
+            }
+            [self showPickerViewController:picker];
+        }];
+    } else {
+      [self showPickerViewController:picker];
+    }
 }
 
 - (void) showPickerViewController:(UIViewController *)picker

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -160,7 +160,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         NSString *creationDate = [formatter stringFromDate:phAsset.creationDate];
         
         asset[@"timestamp"] = creationDate;
-        // asset[@"location"] = phAsset.location;
+        // Add more exif data here ...
     }
     
     return asset;

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -51,7 +51,7 @@
 #if __has_include(<PhotosUI/PHPicker.h>)
     PHPickerConfiguration *configuration;
     
-    if(options[@"includeExif"]) {
+    if(options[@"includeExtra"]) {
         PHPhotoLibrary *photoLibrary = [PHPhotoLibrary sharedPhotoLibrary];
         configuration = [[PHPickerConfiguration alloc] initWithPhotoLibrary:photoLibrary];
     } else {

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -49,7 +49,15 @@
 + (PHPickerConfiguration *)makeConfigurationFromOptions:(NSDictionary *)options target:(RNImagePickerTarget)target API_AVAILABLE(ios(14))
 {
 #if __has_include(<PhotosUI/PHPicker.h>)
-    PHPickerConfiguration *configuration = [[PHPickerConfiguration alloc] init];
+    PHPickerConfiguration *configuration;
+    
+    if(options[@"includeExif"]) {
+        PHPhotoLibrary *photoLibrary = [PHPhotoLibrary sharedPhotoLibrary];
+        configuration = [[PHPickerConfiguration alloc] initWithPhotoLibrary:photoLibrary];
+    } else {
+        configuration = [[PHPickerConfiguration alloc] init];
+    }
+    
     configuration.preferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationModeCurrent;
     configuration.selectionLimit = [options[@"selectionLimit"] integerValue];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   selectionLimit: 1,
   saveToPhotos: false,
   durationLimit: 0,
+  includeExtra: false,
 };
 
 export function launchCamera(options: CameraOptions, callback: Callback) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface ImageLibraryOptions {
   quality?: PhotoQuality;
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
+  includeExif?: boolean;
 }
 
 export interface CameraOptions
@@ -26,6 +27,8 @@ export interface Asset {
   type?: string; //TODO
   fileName?: string;
   duration?: number;
+  timestamp?: string,
+  location?: any,
 }
 
 export interface ImagePickerResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface ImageLibraryOptions {
   quality?: PhotoQuality;
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
-  includeExif?: boolean;
+  includeExtra?: boolean;
 }
 
 export interface CameraOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,6 @@ export interface Asset {
   fileName?: string;
   duration?: number;
   timestamp?: string,
-  location?: any,
 }
 
 export interface ImagePickerResponse {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

This adds the architecture for iOS and Android to optionally offer the ability to include exif data with the selected photos. The requires iOS library permissions, hence `includeExif` defaults to `false`.

## Test Plan (required)

These changes will be released to several thousand users in our production application via our fork.
