### PR TITLE
Support limited photo picking

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -63,6 +63,12 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
 #if __has_include(<PhotosUI/PHPicker.h>)
     if (@available(iOS 14, *)) {
+        PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
+        if (status == PHAuthorizationStatusLimited) {
+            [self showLimitedPickerViewController];
+            return;
+        }
+    
         if (target == library) {
             PHPickerConfiguration *configuration = [ImagePickerUtils makeConfigurationFromOptions:options target:target];
             PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
@@ -86,6 +92,16 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         }
         [self showPickerViewController:picker];
     }];
+}
+
+- (void) showLimitedPickerViewController {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (@available(iOS 14, *)) {
+            UIViewController *root = RCTPresentedViewController();
+            PHPhotoLibrary *limitedPicker = [[PHPhotoLibrary alloc] init];
+            [limitedPicker presentLimitedLibraryPickerFromViewController:root];
+        }
+    });
 }
 
 - (void) showPickerViewController:(UIViewController *)picker


### PR DESCRIPTION
## Motivation (required)

This is an aim to solve issue https://github.com/react-native-image-picker/react-native-image-picker/issues/1749

I added a check for `PHAuthorizationStatusLimited` and presented a limited picker view controller. My Obj-C is pretty rusty/non-existing so this is the best effort I could do. If it requires changes please let me know so I can fix them.

## Test Plan (required)

On an iOS 14+ device, open the image library and select limited photo permissions.