### PR TITLE
iOS 14+ photos permission ask added 

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -68,8 +68,14 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
             picker.delegate = self;
             picker.presentationController.delegate = self;
-
-            [self showPickerViewController:picker];
+            [self checkPermission:^(BOOL granted) {
+                NSLog(@"this is very test image gallery");
+                if (!granted) {
+                    self.callback(@[@{@"errorCode": errPermission}]);
+                    return;
+                }
+                [self showPickerViewController:picker];
+            }];
             return;
         }
     }
@@ -261,12 +267,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         [self checkCameraPermissions:permissionBlock];
     }
     else {
-        if (@available(iOS 11.0, *)) {
-            callback(YES);
-        }
-        else {
-            [self checkPhotosPermissions:permissionBlock];
-        }
+        [self checkPhotosPermissions:permissionBlock];
     }
 }
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -69,7 +69,6 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             picker.delegate = self;
             picker.presentationController.delegate = self;
             [self checkPermission:^(BOOL granted) {
-                NSLog(@"this is very test image gallery");
                 if (!granted) {
                     self.callback(@[@{@"errorCode": errPermission}]);
                     return;


### PR DESCRIPTION
### Above iOS 14 version, Accessing photos permission is not asked from the user which should be the expected behaviour.

I have added functionality to ask permission from user for photos above iOS 14.
Please review ASAP as it was impacting users.

I am successfully done that and attaching screenshot for review purpose.


![image0](https://user-images.githubusercontent.com/54228836/132625252-958d8feb-c76a-4325-8115-03415122e700.jpeg)

