### PR TITLE
Explicitly typecast ReadableMap to WritableMap

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -424,9 +424,9 @@ public class Utils {
                     uri = getAppSpecificStorageUri(uri, context);
                 }
                 uri = resizeImage(uri, context, options);
-                assets.pushMap(getImageResponseMap(uri, options, context));
+                assets.pushMap((WritableMap) getImageResponseMap(uri, options, context));
             } else if (isVideoType(uri, context)) {
-                assets.pushMap(getVideoResponseMap(uri, context));
+                assets.pushMap((WritableMap) getVideoResponseMap(uri, context));
             } else {
                 throw new RuntimeException("Unsupported file type");
             }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

This PR fixes the `incompatible types: ReadableMap cannot be converted to WritableMap` error from the `Utils.java` file. It was fixed by explicitly typecasting the `ReadableMap` object to the `WritableMap` object.

Linked issue: #1759

## Test Plan

This was tested in the proprietary app that I was working on. Sharing any code from there is not possible.