### PR TITLE
feat(android): return video bitrate on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | fileSize  | OK  | OK      | The file size                                                                                                                                                                                                                |
 | type      | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
 | fileName  | OK  | OK      | The file name                                                                                                                                                                                                                              |
-| duration  | OK  | OK      | The selected video duration in seconds (Android only)
+| duration  | OK  | OK      | The selected video duration in seconds
 | bitrate   | --- | OK      | The average bitrate (in bits/sec) of the selected video, if available.|
 | timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExtra' is true
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | type     | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
 | fileName | OK  | OK      | The file name                                                                                                                                                                                                                              |
 | duration | OK  | OK      | The selected video duration in seconds                                                                                                                                                                                                     |
+| bitrate | -  | OK      | The average bitrate (in bits/sec) of the selected video, if available.                                                                                                                                                                                                     |
 
 ## Note on file storage
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | type      | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
 | fileName  | OK  | OK      | The file name                                                                                                                                                                                                                              |
 | duration  | OK  | OK      | The selected video duration in seconds (Android only)
-| bitrate | -  | OK      | The average bitrate (in bits/sec) of the selected video, if available.|
+| bitrate   | --- | OK      | The average bitrate (in bits/sec) of the selected video, if available.|
 | timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExtra' is true
 
 ## Note on file storage

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -8,7 +8,6 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.camera2.CameraCharacteristics;
@@ -17,7 +16,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
-import android.provider.OpenableColumns;
 import android.util.Base64;
 import android.webkit.MimeTypeMap;
 
@@ -263,15 +261,6 @@ public class Utils {
         }
     }
 
-    static VideoMetadata getVideoMetaData(Uri uri, Context context) {
-        MediaMetadataRetriever m = new MediaMetadataRetriever();
-        m.setDataSource(context, uri);
-        int duration = Math.round(Float.parseFloat(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))) / 1000;
-        int bitrate = parseInt(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE));
-        m.release();
-        return new VideoMetadata(duration, bitrate);
-    }
-
     static boolean shouldResizeImage(int origWidth, int origHeight, Options options) {
         if ((options.maxWidth == 0 || options.maxHeight == 0) && options.quality == 100) {
             return false;
@@ -319,24 +308,6 @@ public class Utils {
             case REQUEST_LAUNCH_VIDEO_CAPTURE:
             case REQUEST_LAUNCH_LIBRARY: return true;
             default: return false;
-        }
-    }
-
-    public static class VideoMetadata {
-        int duration;
-        int bitrate;
-
-        public VideoMetadata(int duration, int bitrate) {
-            this.duration = duration;
-            this.bitrate = bitrate;
-        }
-
-        public int getBitrate() {
-            return bitrate;
-        }
-
-        public int getDuration() {
-            return duration;
         }
     }
 
@@ -427,7 +398,7 @@ public class Utils {
         WritableMap map = Arguments.createMap();
         map.putString("uri", uri.toString());
         map.putDouble("fileSize", getFileSize(uri, context));
-        VideoMetadata videoMetadata = getVideoMetaData(uri, context);
+        VideoMetadata videoMetadata = new VideoMetadata(uri, context);
         map.putInt("duration", videoMetadata.getDuration());
         map.putInt("bitrate", videoMetadata.getBitrate());
         map.putString("fileName", fileName);

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -11,7 +11,6 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.camera2.CameraCharacteristics;
-import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
@@ -46,7 +45,6 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.UUID;
 
-import static java.lang.Integer.parseInt;
 import static com.imagepicker.ImagePickerModule.*;
 
 public class Utils {

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static java.lang.Integer.parseInt;
 import static com.imagepicker.ImagePickerModule.*;
 
 public class Utils {
@@ -262,12 +263,13 @@ public class Utils {
         }
     }
 
-    static int getDuration(Uri uri, Context context) {
+    static VideoMetadata getVideoMetaData(Uri uri, Context context) {
         MediaMetadataRetriever m = new MediaMetadataRetriever();
         m.setDataSource(context, uri);
         int duration = Math.round(Float.parseFloat(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))) / 1000;
+        int bitrate = parseInt(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE));
         m.release();
-        return duration;
+        return new VideoMetadata(duration, bitrate);
     }
 
     static boolean shouldResizeImage(int origWidth, int origHeight, Options options) {
@@ -318,6 +320,24 @@ public class Utils {
             case REQUEST_LAUNCH_LIBRARY: return true;
             default: return false;
         }
+    }
+
+    public static class VideoMetadata {
+      int duration;
+      int bitrate;
+
+        public VideoMetadata(int duration, int bitrate) {
+            this.duration = duration;
+            this.bitrate = bitrate;
+        }
+
+         public int getBitrate() {
+            return bitrate;
+         }
+
+         public int getDuration() {
+            return duration;
+          }
     }
 
     // This library does not require Manifest.permission.CAMERA permission, but if user app declares as using this permission which is not granted, then attempting to use ACTION_IMAGE_CAPTURE|ACTION_VIDEO_CAPTURE will result in a SecurityException.
@@ -407,7 +427,9 @@ public class Utils {
         WritableMap map = Arguments.createMap();
         map.putString("uri", uri.toString());
         map.putDouble("fileSize", getFileSize(uri, context));
-        map.putInt("duration", getDuration(uri, context));
+        VideoMetadata videoMetadata = getVideoMetaData(uri, context);
+        map.putInt("duration", videoMetadata.getDuration());
+        map.putInt("bitrate", videoMetadata.getBitrate());
         map.putString("fileName", fileName);
         map.putString("type", getMimeType(uri, context));
         return map;

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -323,21 +323,21 @@ public class Utils {
     }
 
     public static class VideoMetadata {
-      int duration;
-      int bitrate;
+        int duration;
+        int bitrate;
 
         public VideoMetadata(int duration, int bitrate) {
             this.duration = duration;
             this.bitrate = bitrate;
         }
 
-         public int getBitrate() {
+        public int getBitrate() {
             return bitrate;
-         }
+        }
 
-         public int getDuration() {
+        public int getDuration() {
             return duration;
-          }
+        }
     }
 
     // This library does not require Manifest.permission.CAMERA permission, but if user app declares as using this permission which is not granted, then attempting to use ACTION_IMAGE_CAPTURE|ACTION_VIDEO_CAPTURE will result in a SecurityException.

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -1,0 +1,31 @@
+package com.imagepicker;
+
+import static java.lang.Integer.parseInt;
+
+import android.content.Context;
+import android.media.MediaMetadataRetriever;
+import android.net.Uri;
+
+public class VideoMetadata {
+  int duration;
+  int bitrate;
+
+  public VideoMetadata(Uri uri, Context context) {
+    MediaMetadataRetriever m = new MediaMetadataRetriever();
+    m.setDataSource(context, uri);
+    this.duration = Math.round(Float.parseFloat(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))) / 1000;
+    this.bitrate = parseInt(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE));
+    m.release();
+
+
+
+  }
+
+  public int getBitrate() {
+    return bitrate;
+  }
+
+  public int getDuration() {
+    return duration;
+  }
+}

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -13,9 +13,13 @@ public class VideoMetadata {
   public VideoMetadata(Uri uri, Context context) {
     MediaMetadataRetriever m = new MediaMetadataRetriever();
     m.setDataSource(context, uri);
-    this.duration = Math.round(Float.parseFloat(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))) / 1000;
-    this.bitrate = parseInt(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE));
-    m.release();
+    String duration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+    String bitrate = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
+    // Extract anymore metadata here...
+
+    this.duration = Math.round(Float.parseFloat(duration)) / 1000;
+    this.bitrate = parseInt(bitrate);
+    metadataRetriever.release();
   }
 
   public int getBitrate() {

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -11,8 +11,8 @@ public class VideoMetadata {
   int bitrate;
 
   public VideoMetadata(Uri uri, Context context) {
-    MediaMetadataRetriever m = new MediaMetadataRetriever();
-    m.setDataSource(context, uri);
+    MediaMetadataRetriever metadataRetriever = new MediaMetadataRetriever();
+    metadataRetriever.setDataSource(context, uri);
     String duration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
     String bitrate = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
     // Extract anymore metadata here...

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -16,9 +16,6 @@ public class VideoMetadata {
     this.duration = Math.round(Float.parseFloat(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))) / 1000;
     this.bitrate = parseInt(m.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE));
     m.release();
-
-
-
   }
 
   public int getBitrate() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Asset {
   type?: string;
   fileName?: string;
   duration?: number;
+  bitrate?: number;
 }
 
 export interface ImagePickerResponse {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch. <-- P/R template should be updated to say `main` branch

## Motivation (required)

Returns the bitrate of the video on Android

## Test Plan (required)

Could not get unit tests to run, but I did run the example app and ensured the bitrate is returned when selecting a video on Android

<img src="https://user-images.githubusercontent.com/14185925/137587240-42ef0f0c-8b20-435b-a534-73faa6a50664.png" width="300" />


Retest since updates:
<img width="384" alt="Screenshot 2021-12-09 at 12 35 11" src="https://user-images.githubusercontent.com/14185925/145397976-786642d9-2628-4809-9e1c-36a1e7f8270b.png">


