### PR TITLE
fix(ios): return full video duration on iOS

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -178,7 +178,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
     
     NSMutableDictionary *asset = [[NSMutableDictionary alloc] init];
-    asset[@"duration"] = @(roundf(CMTimeGetSeconds([AVAsset assetWithURL:videoDestinationURL].duration)));
+    asset[@"duration"] = [NSNumber numberWithDouble:CMTimeGetSeconds([AVAsset assetWithURL:videoDestinationURL].duration)];
     asset[@"uri"] = videoDestinationURL.absoluteString;
     asset[@"type"] = [ImagePickerUtils getFileTypeFromUrl:videoDestinationURL];
     


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

To accurately validate the video based on its duration. Unable to do so currently as duration is rounded to the nearest second. 

For example, if your app has a limit of 60 seconds, but the video is actually 60.4 it will be rounded down, to 60 causing an unexpected error during upload

Will fix https://github.com/react-native-image-picker/react-native-image-picker/issues/1842

## Test Plan (required)
<img width="389" alt="Screenshot 2021-10-16 at 16 13 37" src="https://user-images.githubusercontent.com/14185925/137593558-b4c47bd9-47d7-4b12-b57c-3e7624184c8d.png">


