### PR TITLE
fix: photo selection in simulator on M1 macs

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -376,13 +376,14 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
                 [assets addObject:[self mapImageToAsset:image data:data]];
                 dispatch_group_leave(completionGroup);
             }];
-        }
-
-        if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeMovie]) {
+        } else if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeMovie]) {
             [provider loadFileRepresentationForTypeIdentifier:(NSString *)kUTTypeMovie completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
                 [assets addObject:[self mapVideoToAsset:url error:nil]];
                 dispatch_group_leave(completionGroup);
             }];
+        } else {
+            // The provider didn't have an item matching photo or video (fails on M1 Mac Simulator)
+            dispatch_group_leave(completionGroup)
         }
     }
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -375,7 +375,9 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
                 // Handle live photos
                 identifier = @"public.jpeg";
             }
-            [provider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData * _Nullable data, NSError * _Nullable error) {
+
+            [provider loadFileRepresentationForTypeIdentifier:identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                NSData *data = [[NSData alloc] initWithContentsOfURL:url];
                 UIImage *image = [[UIImage alloc] initWithData:data];
 
                 [assets addObject:[self mapImageToAsset:image data:data]];
@@ -391,6 +393,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             dispatch_group_leave(completionGroup);
         }
     }
+
     dispatch_group_notify(completionGroup, dispatch_get_main_queue(), ^{
         //  mapVideoToAsset can fail and return nil.
         for (NSDictionary *asset in assets) {

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -369,8 +369,13 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         NSItemProvider *provider = result.itemProvider;
         dispatch_group_enter(completionGroup);
 
-        if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
-            [provider loadDataRepresentationForTypeIdentifier:(NSString *)kUTTypeImage completionHandler:^(NSData * _Nullable data, NSError * _Nullable error) {
+        if ([provider canLoadObjectOfClass:[UIImage class]]) {
+            NSString *identifier = provider.registeredTypeIdentifiers.firstObject;
+            if ([identifier isEqualToString:@"com.apple.live-photo-bundle"]) {
+                // Handle live photos
+                identifier = @"public.jpeg";
+            }
+            [provider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData * _Nullable data, NSError * _Nullable error) {
                 UIImage *image = [[UIImage alloc] initWithData:data];
 
                 [assets addObject:[self mapImageToAsset:image data:data]];
@@ -386,7 +391,6 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             dispatch_group_leave(completionGroup);
         }
     }
-
     dispatch_group_notify(completionGroup, dispatch_get_main_queue(), ^{
         //  mapVideoToAsset can fail and return nil.
         for (NSDictionary *asset in assets) {

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -383,7 +383,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             }];
         } else {
             // The provider didn't have an item matching photo or video (fails on M1 Mac Simulator)
-            dispatch_group_leave(completionGroup)
+            dispatch_group_leave(completionGroup);
         }
     }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve? https://github.com/react-native-image-picker/react-native-image-picker/issues/1541

Right now I'm looking for general thoughts on whether this is an acceptable fix. I pulled it from the PHPickerController changes made to react-native-image-crop-picker.

## Test Plan (required)

Looking for recommendations here. So far I've been testing on the app I've been developing on that benefitted from this fix.

TODO:
- [x] test adding a simulator photo and accessing it from the `launchImageLibrary` callback
- [x] confirm fix does not break behavior on actual device
- [ ] confirm fix does not break simulator on intel devices (no intel device available)
- [x] test inside example project rather than my project

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
