### PR TITLE
fix(android): return the original 'uri' instead of null when resizeImage has failed

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -212,7 +212,7 @@ public class Utils {
 
         } catch (Exception e) {
             e.printStackTrace();
-            return  null;
+            return uri; // cannot resize the image, return the original uri
         }
     }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [  ] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

From #1699, I believe it is not safe to close the issue as latest code the report has already taken into `NullPointerException` with a more broad `RuntimeException`. Anyway, I find that it can be more stronger by instead of returning null (in `resizeImage` method which would trigger NPE in the first place), we can simply return the original uri.

## Test Plan (required)

I am not really sure if I can have a concrete test plan for this one-line change. It is a simple improvement to the existing codebase.