### PR TITLE
feat(api): added methods to launch the image picker and camera as promise 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A React Native module that allows you to select a photo/video from the device li
 </p>
 
 ### Make sure you're reading the doc applicable to your version, for example if your using version 3.8.0 go to tag 3.8.0 and read those docs. This doc is always that of main branch.
-### Also read version release notes for any breaking changes especially if you're updating the major version.
 
+### Also read version release notes for any breaking changes especially if you're updating the major version.
 
 # Install
 
@@ -67,8 +67,6 @@ The `callback` will be called with a response object, refer to [The Response Obj
 const result : ImagePickerResponse = await launchCameraAsPromise(options?);
 ```
 
-See [Options](#options) for further information on `options`.
-
 ### `launchImageLibrary`
 
 Launch gallery to pick image or video.
@@ -87,31 +85,29 @@ The `callback` will be called with a response object, refer to [The Response Obj
 const result : ImagePickerResponse = await launchImageLibraryAsPromise(options?);
 ```
 
-See [Options](#options) for further information on `options`.
-
 ## Options
 
-| Option        | iOS | Android | Description                                                                                           |
-| ------------- | --- | ------- | ----------------------------------------------------------------------------------------------------- |
-| mediaType     | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video) |
-| maxWidth      | OK  | OK      | To resize the image                                                                                   |
-| maxHeight     | OK  | OK      | To resize the image                                                                                   |
-| videoQuality  | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                         |
-| durationLimit | OK  | OK      | Video max duration in seconds                                                                         |
-| quality       | OK  | OK      | 0 to 1, photos                                                                                        |
-| cameraType    | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                        |
-| includeBase64 | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)     |
-| saveToPhotos  | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                  |
-| selectionLimit| OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value|
+| Option         | iOS | Android | Description                                                                                                                               |
+| -------------- | --- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| mediaType      | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video)                                     |
+| maxWidth       | OK  | OK      | To resize the image                                                                                                                       |
+| maxHeight      | OK  | OK      | To resize the image                                                                                                                       |
+| videoQuality   | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                             |
+| durationLimit  | OK  | OK      | Video max duration in seconds                                                                                                             |
+| quality        | OK  | OK      | 0 to 1, photos                                                                                                                            |
+| cameraType     | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                            |
+| includeBase64  | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                         |
+| saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
+| selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
 
 ## The Response Object
 
-| key                         | iOS | Android | Description                                             |
-| --------------------------- | --- | ------- | ------------------------------------------------------- |
-| didCancel                   | OK  | OK      | `true` if the user cancelled the process                |
-| errorCode                   | OK  | OK      | Check [ErrorCode](#ErrorCode) for all error codes       |
-| errorMessage                | OK  | OK      | Description of the error, use it for debug purpose only |
-| assets                      | OK  | OK      | Array of the selected media, [refer to Asset Object](#Asset-Object) |
+| key          | iOS | Android | Description                                                         |
+| ------------ | --- | ------- | ------------------------------------------------------------------- |
+| didCancel    | OK  | OK      | `true` if the user cancelled the process                            |
+| errorCode    | OK  | OK      | Check [ErrorCode](#ErrorCode) for all error codes                   |
+| errorMessage | OK  | OK      | Description of the error, use it for debug purpose only             |
+| assets       | OK  | OK      | Array of the selected media, [refer to Asset Object](#Asset-Object) |
 
 ## Asset Object
 
@@ -121,7 +117,7 @@ See [Options](#options) for further information on `options`.
 | uri      | OK  | OK      | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
 | width    | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
 | height   | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
-| fileSize | OK  | OK      | The file size (except for videos on Android)                                                                                                                                                                                                                |
+| fileSize | OK  | OK      | The file size (except for videos on Android)                                                                                                                                                                                               |
 | type     | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
 | fileName | OK  | OK      | The file name                                                                                                                                                                                                                              |
 | duration | OK  | OK      | The selected video duration in seconds                                                                                                                                                                                                     |

--- a/README.md
+++ b/README.md
@@ -55,35 +55,29 @@ Launch camera to take photo or video.
 
 ```js
 launchCamera(options?, callback);
+
+// You can also use as a promise without 'callback':
+const result = await launchCamera(options?);
 ```
 
 See [Options](#options) for further information on `options`.
 
 The `callback` will be called with a response object, refer to [The Response Object](#the-response-object).
-
-#### `launchCameraAsPromise`
-
-```ts
-const result : ImagePickerResponse = await launchCameraAsPromise(options?);
-```
 
 ### `launchImageLibrary`
 
 Launch gallery to pick image or video.
 
 ```js
-launchImageLibrary(options?, callback);
+launchImageLibrary(options?, callback)
+
+// You can also use as a promise without 'callback':
+const result = await launchImageLibrary(options?);
 ```
 
 See [Options](#options) for further information on `options`.
 
 The `callback` will be called with a response object, refer to [The Response Object](#the-response-object).
-
-#### `launchImageLibraryAsPromise`
-
-```ts
-const result : ImagePickerResponse = await launchImageLibraryAsPromise(options?);
-```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ See [Options](#options) for further information on `options`.
 
 The `callback` will be called with a response object, refer to [The Response Object](#the-response-object).
 
+#### `launchCameraAsPromise`
+
+```ts
+const result : ImagePickerResponse = await launchCameraAsPromise(options?);
+```
+
+See [Options](#options) for further information on `options`.
+
 ### `launchImageLibrary`
 
 Launch gallery to pick image or video.
@@ -72,6 +80,14 @@ launchImageLibrary(options?, callback)
 See [Options](#options) for further information on `options`.
 
 The `callback` will be called with a response object, refer to [The Response Object](#the-response-object).
+
+#### `launchImageLibraryAsPromise`
+
+```ts
+const result : ImagePickerResponse = await launchImageLibraryAsPromise(options?);
+```
+
+See [Options](#options) for further information on `options`.
 
 ## Options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,40 +17,30 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   includeExtra: false,
 };
 
-export function launchCameraAsPromise(options: CameraOptions) : Promise<ImagePickerResponse> {
+export function launchCamera(options: CameraOptions, callback?: Callback) : Promise<ImagePickerResponse> {
   return new Promise(resolve => {
-    launchCamera(options, result => resolve(result));
-  });
-}
-
-export function launchCamera(options: CameraOptions, callback: Callback) {
-  if (typeof callback !== 'function') {
-    console.error("Send proper callback function, check API");
-    return;
-  }
-
-  NativeModules.ImagePickerManager.launchCamera(
-    {...DEFAULT_OPTIONS, ...options},
-    callback,
-  );
-}
-
-export function launchImageLibraryAsPromise(options: ImageLibraryOptions) : Promise<ImagePickerResponse> {
-  return new Promise(resolve => {
-    launchImageLibrary(options, result => resolve(result));
-  });
+    NativeModules.ImagePickerManager.launchCamera(
+      {...DEFAULT_OPTIONS, ...options},
+      (result: ImagePickerResponse) => {
+        if(callback) callback(result);
+        resolve(result);
+      },
+    );
+  });  
 }
 
 export function launchImageLibrary(
   options: ImageLibraryOptions,
-  callback: Callback,
-) {
-  if (typeof callback !== 'function') {
-    console.error("Send proper callback function, check API");
-    return;
-  }
-  NativeModules.ImagePickerManager.launchImageLibrary(
-    {...DEFAULT_OPTIONS, ...options},
-    callback,
-  );
+  callback?: Callback,
+) : Promise<ImagePickerResponse> {
+  return new Promise(resolve => {
+    NativeModules.ImagePickerManager.launchImageLibrary(
+      {...DEFAULT_OPTIONS, ...options},
+      (result: ImagePickerResponse) => {
+        if(callback) callback(result);
+        resolve(result);
+      },
+    );
+  })
+  
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {NativeModules} from 'react-native';
 
-import {CameraOptions, ImageLibraryOptions, Callback} from './types';
+import {CameraOptions, ImageLibraryOptions, Callback, ImagePickerResponse} from './types';
 export * from './types';
 
 const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
@@ -16,6 +16,12 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   durationLimit: 0,
 };
 
+export function launchCameraAsPromise(options: CameraOptions) : Promise<ImagePickerResponse> {
+  return new Promise(resolve => {
+    launchCamera(options, result => resolve(result));
+  });
+}
+
 export function launchCamera(options: CameraOptions, callback: Callback) {
   if (typeof callback !== 'function') {
     console.error("Send proper callback function, check API");
@@ -26,6 +32,12 @@ export function launchCamera(options: CameraOptions, callback: Callback) {
     {...DEFAULT_OPTIONS, ...options},
     callback,
   );
+}
+
+export function launchImageLibraryAsPromise(options: ImageLibraryOptions) : Promise<ImagePickerResponse> {
+  return new Promise(resolve => {
+    launchImageLibrary(options, result => resolve(result));
+  });
 }
 
 export function launchImageLibrary(


### PR DESCRIPTION
- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Easier API for those who want to work with promises instead of callbacks. I have found myself moving 'promisifying' code across multiple projects which use this library.

## Test Plan (required)

New additions so only basic testing is needed as there is no risk of regression. We have ran tests within out application from our fork: https://github.com/Qeepsake/react-native-image-picker