### PR TITLE
fix: selectionLimit assets return on android

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -436,8 +436,15 @@ public class Utils {
 
     static ReadableMap getResponseMap(List<Uri> fileUris, Options options, Context context) throws RuntimeException {
         WritableArray assets = Arguments.createArray();
+        int size;
+        if(fileUris.size() > options.selectionLimit) {
+            size = options.selectionLimit;
+        }
+        else {
+            size = fileUris.size();
+        }
 
-        for(int i = 0; i < fileUris.size(); ++i) {
+        for(int i = 0; i < size; ++i) {
             Uri uri = fileUris.get(i);
 
             if (isImageType(uri, context)) {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Hai, im using the `selectionLimit` options on to limit the maximum selection file that user can do. On ios, this work fine as video below.

https://user-images.githubusercontent.com/16449020/143539168-ba2e0f49-4805-47f9-80fb-047c9a85bd72.mp4

it block the user from select more than the limit and return the selection as the limit. But on android, user can select as much as possible and the return is all the user selection.

https://user-images.githubusercontent.com/16449020/143539308-57e1b796-a018-4453-bad4-e585ed896fa0.mp4

as what i read from SO https://stackoverflow.com/questions/33604951/maximum-image-selection-limit-from-gallery-android, it need to validate again the selection file as the limit. In this PR, im improve to return only the amount of selected image as set in selectionLimit options. Please see the video below.

https://user-images.githubusercontent.com/16449020/143539552-04f9907c-8fb0-43c0-a8fd-b8b2bda32d18.mp4

## Test Plan (required)

- confused on how to add test

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
