### PR TITLE
fix: 1759 - getImageResponseMap and getVideoResponseMap return type

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -387,7 +387,7 @@ public class Utils {
         return fileUris;
     }
 
-    static ReadableMap getImageResponseMap(Uri uri, Options options, Context context) {
+    static WritableArray getImageResponseMap(Uri uri, Options options, Context context) {
         String fileName = uri.getLastPathSegment();
         int[] dimensions = getImageDimensions(uri, context);
 
@@ -423,7 +423,7 @@ public class Utils {
         return map;
     }
 
-    static ReadableMap getVideoResponseMap(Uri uri, Context context) {
+    static WritableArray getVideoResponseMap(Uri uri, Context context) {
         String fileName = uri.getLastPathSegment();
         WritableMap map = Arguments.createMap();
         map.putString("uri", uri.toString());


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

This PR fixes the incompatible types: ReadableMap cannot be converted to WritableMap error from the Utils.java file. getResponseMap method is returning an array of assets of type WritableArray but method `getImageResponseMap` and `getVideoResponseMap` are ReadableMap type.

Linked issue: #1759

## Test Plan (required)

No test plan since this was fixed on a proprietary app, Tested locally with version 4.3.0.