### PR TITLE
feat(ios): Add `fileName` to video assets

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -203,6 +203,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
     
     NSMutableDictionary *asset = [[NSMutableDictionary alloc] init];
+    asset[@"fileName"] = fileName;
     asset[@"duration"] = [NSNumber numberWithDouble:CMTimeGetSeconds([AVAsset assetWithURL:videoDestinationURL].duration)];
     asset[@"uri"] = videoDestinationURL.absoluteString;
     asset[@"type"] = [ImagePickerUtils getFileTypeFromUrl:videoDestinationURL];


### PR DESCRIPTION
Fixes: #1670

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

The file name of videos on iOS hasn't been present in their asset objects, as it has for photos. This fixes that.

## Test Plan

<img width=400 src="https://user-images.githubusercontent.com/22248748/144531138-5e927ca8-65d4-49a3-8898-5a7e726b21b3.png" />


