### PR TITLE
fix(issues): fixes #1734 and #1874 by throwing and catching errors correctly

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -22,6 +22,7 @@ import android.util.Base64;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 
+import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.FileProvider;
 import androidx.exifinterface.media.ExifInterface;
@@ -37,12 +38,17 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -350,18 +356,33 @@ public class Utils {
     }
 
     static boolean isImageType(Uri uri, Context context) {
-        final String imageMimeType = "image/";
-
-        return getMimeType(uri, context).contains(imageMimeType);
+      return Utils.isContentType("image/", uri, context);
     }
 
     static boolean isVideoType(Uri uri, Context context) {
-        final String videoMimeType = "video/";
-
-        return getMimeType(uri, context).contains(videoMimeType);
+        return Utils.isContentType("video/", uri, context);
     }
 
-    static String getMimeType(Uri uri, Context context) {
+  /**
+   * Verifies the content typs of a file URI. A helper function
+   * for isVideoType and isImageType
+   *
+   * @param contentMimeType - "video/" or "image/"
+   * @param uri - file uri
+   * @param context - react context
+   * @return a boolean to determine if file is of specified content type i.e. image or video
+   */
+    static boolean isContentType(String contentMimeType, Uri uri, Context context) {
+      final String mimeType = getMimeType(uri, context);
+
+      if(mimeType != null) {
+        return mimeType.contains(contentMimeType);
+      }
+
+      return false;
+    }
+
+    static @Nullable String getMimeType(Uri uri, Context context) {
       if (uri.getScheme().equals("file")) {
         return getMimeTypeFromFileUri(uri);
       }
@@ -405,22 +426,66 @@ public class Utils {
         }
 
         if(options.includeExtra) {
-          try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
-            ExifInterface exif = new ExifInterface(inputStream);
-            Date datetime = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss").parse(exif.getAttribute(ExifInterface.TAG_DATETIME));
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-            String datetimeAsString =  formatter.format(datetime);
-
-            // Add more exif data here ...
-
-            map.putString("timestamp", datetimeAsString);
-          } catch (Exception e) {
-            Log.e("RNIP", "Could not load image exif data: " + e.getMessage());
-          }
+          String datetime = getDateTimeExif(uri, context);
+          // Add more exif data here ...
+          map.putString("timestamp", datetime);
         }
 
         return map;
+    }
+
+  /**
+   * Gets the datetime exif data from a Uri
+   *
+   * @param uri - uri of file
+   * @param context - react context
+   * @return formatted timestamp
+   */
+    static @Nullable String getDateTimeExif(Uri uri, Context context) {
+      try {
+        InputStream inputStream = context.getContentResolver().openInputStream(uri);
+        ExifInterface exif = new ExifInterface(inputStream);
+        String datetimeTag = exif.getAttribute(ExifInterface.TAG_DATETIME);
+        
+        if(datetimeTag != null) {
+          return getDateTimeInUTC(datetimeTag, "yyyy:MM:dd HH:mm:ss");
+        }
+
+        return null;
+      } catch (Exception e) {
+        // This error does not bubble up to RN as we don't want failed datetime retrieval to prevent selection
+        Log.e("RNIP", "Could not load image exif datetime: " + e.getMessage());
+        return null;
+      }
+    }
+
+  /**
+   * Converts a timestamp to a UTC timestamp
+   *
+   * @param value - timestamp
+   * @param format - input format
+   * @return formatted timestamp
+   */
+    static @Nullable String getDateTimeInUTC(String value, String format) {
+      Log.i("RNIF", "Date value:" + value);
+
+      try {
+        Date datetime = new SimpleDateFormat(format, Locale.US).parse(value);
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        Log.i("RNIF", "parsed datetime" + datetime);
+
+        if (datetime != null) {
+          return formatter.format(datetime);
+        }
+
+        return null;
+      } catch (Exception e) {
+        // This error does not bubble up to RN as we don't want failed datetime parsing to prevent selection
+        Log.e("RNIP", "Could not parse image datetime to UTC: " + e.getMessage());
+        return null;
+      }
     }
 
     static ReadableMap getVideoResponseMap(Uri uri, Context context) {

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -467,14 +467,10 @@ public class Utils {
    * @return formatted timestamp
    */
     static @Nullable String getDateTimeInUTC(String value, String format) {
-      Log.i("RNIF", "Date value:" + value);
-
       try {
         Date datetime = new SimpleDateFormat(format, Locale.US).parse(value);
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-        Log.i("RNIF", "parsed datetime" + datetime);
 
         if (datetime != null) {
           return formatter.format(datetime);


### PR DESCRIPTION
- "Unsupported file type" error was not thrown when mimeType could not be found (i.e. ICO files). Closes #1734 
- Exif data was trowing error when trying to run `SimpleDateFormat(...).parse(...)` on a null object (seems like a lot of photos on Android don't include exif say if they have been edited using an different app or downloaded from internet). Closes #1874 
