### PR TITLE
fix (iOS): correct MIME-type for JPEG files

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -133,7 +133,11 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
     
     NSMutableDictionary *asset = [[NSMutableDictionary alloc] init];
-    asset[@"type"] = [@"image/" stringByAppendingString:fileType];
+    if ([fileType isEqualToString:@"jpg"]) {
+        asset[@"type"] = [@"image/" stringByAppendingString:@"jpeg"];
+    } else {
+        asset[@"type"] = [@"image/" stringByAppendingString:fileType];
+    }
 
     NSString *fileName = [self getImageFileName:fileType];
     NSString *path = [[NSTemporaryDirectory() stringByStandardizingPath] stringByAppendingPathComponent:fileName];


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Correct MIME-type for [JPEG files](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#jpeg_joint_photographic_experts_group_image) is 'image/jpeg' while file extensions vary (jpeg, jpg etc.).

It may lead to some edge cases with correct decoding like the one described [here](https://github.com/react-native-image-picker/react-native-image-picker/issues/1856)

Only iOS version seems to be affected.

## Test Plan (required)
Without fix
![Without fix](https://user-images.githubusercontent.com/80260839/145576993-1aa6613e-552a-402e-bb73-37195a33b6a7.png)

With fix
![With fix](https://user-images.githubusercontent.com/80260839/145577011-f5b664dd-746c-4b48-8b14-337d3380d134.png)

P. S. I'll appreciate if someone more familiar with iOS code suggest a more elegant solution or find potential pitfalls here, 'cause I'm new to it.