### PR TITLE
feat(metadata): added width, height and datetime to video for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,19 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Asset Object
 
-| key       | iOS | Android | Description                                                                                                                                                                                                                                |
-| --------- | --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| base64    | OK  | OK      | The base64 string of the image (photos only)                                                                                                                                                                                               |
-| uri       | OK  | OK      | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
-| width     | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
-| height    | OK  | OK      | Image dimensions (photos only)                                                                                                                                                                                                             |
-| fileSize  | OK  | OK      | The file size                                                                                                                                                                                                                |
-| type      | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
-| fileName  | OK  | OK      | The file name   
-| duration  | OK  | OK      | The selected video duration in seconds
-| bitrate   | --- | OK      | The average bitrate (in bits/sec) of the selected video, if available. (Android only)
-| timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExtra' is true
-| id | OK  | OK      | local identifier of the photo or video. On Android, this is the same as fileName |
+| key       | iOS | Android | Photo/Video | Requires Permissions | Description               |
+| --------- | --- | ------- | ----------- | -------------------- | ------------------------- |
+| base64    | OK  | OK      | PHOTO ONLY  | NO                   | The base64 string of the image (photos only) |
+| uri       | OK  | OK      | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
+| width     | OK  | OK      | BOTH        | NO                   | Asset dimensions                |
+| height    | OK  | OK      | BOTH        | NO                   | Asset dimensions                |
+| fileSize  | OK  | OK      | BOTH        | NO                   | The file size                                 |
+| type      | OK  | OK      | BOTH        | NO                   | The file type                                 |
+| fileName  | OK  | OK      | BOTH        | NO                   | The file name                                 |
+| duration  | OK  | OK      | VIDEO ONLY  | NO                   | The selected video duration in seconds        |
+| bitrate   | --- | OK      | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only) |
+| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true |
+| id        | OK  | OK      | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName |
 
 ## Note on file storage
 

--- a/android/src/main/java/com/imagepicker/ImageMetadata.java
+++ b/android/src/main/java/com/imagepicker/ImageMetadata.java
@@ -20,4 +20,14 @@ public class ImageMetadata extends Metadata {
       Log.e("RNIP", "Could not load image metadata: " + e.getMessage());
     }
   }
+
+  @Override
+  public String getDateTime() { return datetime; }
+  
+  // At the moment we are not using the ImageMetadata class to get width/height
+  // TODO: to use this class for extracting image width and height in the future
+  @Override
+  public int getWidth() { return 0; }
+  @Override
+  public int getHeight() { return 0; }
 }

--- a/android/src/main/java/com/imagepicker/ImageMetadata.java
+++ b/android/src/main/java/com/imagepicker/ImageMetadata.java
@@ -1,0 +1,23 @@
+package com.imagepicker;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+import androidx.exifinterface.media.ExifInterface;
+import java.io.InputStream;
+
+public class ImageMetadata extends Metadata {
+  public ImageMetadata(Uri uri, Context context) {
+    try {
+      InputStream inputStream = context.getContentResolver().openInputStream(uri);
+      ExifInterface exif = new ExifInterface(inputStream);
+      String datetimeTag = exif.getAttribute(ExifInterface.TAG_DATETIME);
+
+      // Extract anymore metadata here...
+      if(datetimeTag != null) this.datetime = getDateTimeInUTC(datetimeTag, "yyyy:MM:dd HH:mm:ss");
+    } catch (Exception e) {
+      // This error does not bubble up to RN as we don't want failed datetime retrieval to prevent selection
+      Log.e("RNIP", "Could not load image metadata: " + e.getMessage());
+    }
+  }
+}

--- a/android/src/main/java/com/imagepicker/Metadata.java
+++ b/android/src/main/java/com/imagepicker/Metadata.java
@@ -9,14 +9,14 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-public class Metadata {
+abstract class Metadata {
   protected String datetime;
   protected int height;
   protected int width;
 
-  public String getDateTime() { return datetime; }
-  public int getWidth() { return width; }
-  public int getHeight() { return height; }
+  abstract public String getDateTime();
+  abstract public int getWidth();
+  abstract public int getHeight();
 
   /**
    * Converts a timestamp to a UTC timestamp

--- a/android/src/main/java/com/imagepicker/Metadata.java
+++ b/android/src/main/java/com/imagepicker/Metadata.java
@@ -1,0 +1,46 @@
+package com.imagepicker;
+
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class Metadata {
+  protected String datetime;
+  protected int height;
+  protected int width;
+
+  public String getDateTime() { return datetime; }
+  public int getWidth() { return width; }
+  public int getHeight() { return height; }
+
+  /**
+   * Converts a timestamp to a UTC timestamp
+   *
+   * @param value - timestamp
+   * @param format - input format
+   * @return formatted timestamp
+   */
+  protected @Nullable
+  String getDateTimeInUTC(String value, String format) {
+    try {
+      Date datetime = new SimpleDateFormat(format, Locale.US).parse(value);
+      SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
+      formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+      if (datetime != null) {
+        return formatter.format(datetime);
+      }
+
+      return null;
+    } catch (Exception e) {
+      // This error does not bubble up to RN as we don't want failed datetime parsing to prevent selection
+      Log.e("RNIP", "Could not parse image datetime to UTC: " + e.getMessage());
+      return null;
+    }
+  }
+}

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.camera2.CameraCharacteristics;
+import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
@@ -31,6 +32,7 @@ import com.facebook.react.bridge.WritableMap;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -432,7 +434,7 @@ public class Utils {
         InputStream inputStream = context.getContentResolver().openInputStream(uri);
         ExifInterface exif = new ExifInterface(inputStream);
         String datetimeTag = exif.getAttribute(ExifInterface.TAG_DATETIME);
-        
+
         if(datetimeTag != null) {
           return getDateTimeInUTC(datetimeTag, "yyyy:MM:dd HH:mm:ss");
         }
@@ -480,8 +482,13 @@ public class Utils {
         map.putInt("bitrate", videoMetadata.getBitrate());
         map.putString("fileName", fileName);
         map.putString("type", getMimeType(uri, context));
+        map.putInt("width", videoMetadata.getWidth());
+        map.putInt("height", videoMetadata.getHeight());
 
         if(options.includeExtra) {
+          String datetime = getDateTimeExif(uri, context);
+          // Add more extra data here ...
+          map.putString("timestamp", datetime);
           map.putString("id", fileName);
         }
 

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -11,13 +11,11 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.camera2.CameraCharacteristics;
-import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
 import android.util.Base64;
-import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import androidx.annotation.Nullable;
@@ -32,19 +30,14 @@ import com.facebook.react.bridge.WritableMap;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
 import java.util.UUID;
 
 import static com.imagepicker.ImagePickerModule.*;
@@ -397,6 +390,7 @@ public class Utils {
 
     static ReadableMap getImageResponseMap(Uri uri, Options options, Context context) {
         String fileName = uri.getLastPathSegment();
+        ImageMetadata imageMetadata = new ImageMetadata(uri, context);
         int[] dimensions = getImageDimensions(uri, context);
 
         WritableMap map = Arguments.createMap();
@@ -413,71 +407,21 @@ public class Utils {
         }
 
         if(options.includeExtra) {
-          String datetime = getDateTimeExif(uri, context);
           // Add more extra data here ...
-          map.putString("timestamp", datetime);
+          map.putString("timestamp", imageMetadata.getDateTime());
           map.putString("id", fileName);
         }
 
         return map;
     }
 
-  /**
-   * Gets the datetime exif data from a Uri
-   *
-   * @param uri - uri of file
-   * @param context - react context
-   * @return formatted timestamp
-   */
-    static @Nullable String getDateTimeExif(Uri uri, Context context) {
-      try {
-        InputStream inputStream = context.getContentResolver().openInputStream(uri);
-        ExifInterface exif = new ExifInterface(inputStream);
-        String datetimeTag = exif.getAttribute(ExifInterface.TAG_DATETIME);
-
-        if(datetimeTag != null) {
-          return getDateTimeInUTC(datetimeTag, "yyyy:MM:dd HH:mm:ss");
-        }
-
-        return null;
-      } catch (Exception e) {
-        // This error does not bubble up to RN as we don't want failed datetime retrieval to prevent selection
-        Log.e("RNIP", "Could not load image exif datetime: " + e.getMessage());
-        return null;
-      }
-    }
-
-  /**
-   * Converts a timestamp to a UTC timestamp
-   *
-   * @param value - timestamp
-   * @param format - input format
-   * @return formatted timestamp
-   */
-    static @Nullable String getDateTimeInUTC(String value, String format) {
-      try {
-        Date datetime = new SimpleDateFormat(format, Locale.US).parse(value);
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-        if (datetime != null) {
-          return formatter.format(datetime);
-        }
-
-        return null;
-      } catch (Exception e) {
-        // This error does not bubble up to RN as we don't want failed datetime parsing to prevent selection
-        Log.e("RNIP", "Could not parse image datetime to UTC: " + e.getMessage());
-        return null;
-      }
-    }
-
     static ReadableMap getVideoResponseMap(Uri uri, Options options, Context context) {
         String fileName = uri.getLastPathSegment();
         WritableMap map = Arguments.createMap();
+        VideoMetadata videoMetadata = new VideoMetadata(uri, context);
+
         map.putString("uri", uri.toString());
         map.putDouble("fileSize", getFileSize(uri, context));
-        VideoMetadata videoMetadata = new VideoMetadata(uri, context);
         map.putInt("duration", videoMetadata.getDuration());
         map.putInt("bitrate", videoMetadata.getBitrate());
         map.putString("fileName", fileName);
@@ -486,9 +430,8 @@ public class Utils {
         map.putInt("height", videoMetadata.getHeight());
 
         if(options.includeExtra) {
-          String datetime = getDateTimeExif(uri, context);
           // Add more extra data here ...
-          map.putString("timestamp", datetime);
+          map.putString("timestamp", videoMetadata.getDateTime());
           map.putString("id", fileName);
         }
 

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -3,22 +3,36 @@ package com.imagepicker;
 import static java.lang.Integer.parseInt;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 public class VideoMetadata {
   int duration;
   int bitrate;
+  private Bitmap bitmap = null;
 
   public VideoMetadata(Uri uri, Context context) {
     MediaMetadataRetriever metadataRetriever = new MediaMetadataRetriever();
     metadataRetriever.setDataSource(context, uri);
+    Bitmap bitmap = null;
+
+
     String duration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
     String bitrate = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
     // Extract anymore metadata here...
 
     this.duration = Math.round(Float.parseFloat(duration)) / 1000;
     this.bitrate = parseInt(bitrate);
+    this.bitmap = getBitmap(uri, metadataRetriever);
     metadataRetriever.release();
   }
 
@@ -28,5 +42,43 @@ public class VideoMetadata {
 
   public int getDuration() {
     return duration;
+  }
+
+  public int getWidth() {
+    if(this.bitmap != null) {
+      return this.bitmap.getWidth();
+    }
+
+    return 0;
+  }
+
+  public int getHeight() {
+    if(this.bitmap != null) {
+      return this.bitmap.getHeight();
+    }
+
+    return 0;
+  }
+
+  private @Nullable
+  Bitmap getBitmap(Uri uri, MediaMetadataRetriever retriever) {
+    FileInputStream inputStream = null;
+    File file = new File(uri.getPath());
+
+    // These errors do not bubble up to RN as we don't want failed width/height
+    // retrieval to prevent selection.
+    try {
+      inputStream = new FileInputStream(file.getAbsolutePath());
+      retriever.setDataSource(inputStream.getFD());
+      return retriever.getFrameAtTime();
+    } catch (FileNotFoundException e) {
+      Log.e("RNIP", "Could not retrieve width and height from video: " + e.getMessage());
+    } catch (IOException e) {
+      Log.e("RNIP", "Could not retrieve width and height from video: " + e.getMessage());
+    } catch (RuntimeException e) {
+      Log.e("RNIP", "Could not retrieve width and height from video: " + e.getMessage());
+    }
+
+    return null;
   }
 }

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -52,6 +52,12 @@ public class VideoMetadata extends Metadata {
   public int getDuration() {
     return duration;
   }
+  @Override
+  public String getDateTime() { return datetime; }
+  @Override
+  public int getWidth() { return width; }
+  @Override
+  public int getHeight() { return height; }
 
   private @Nullable
   Bitmap getBitmap(Uri uri, Context context, MediaMetadataRetriever retriever) {

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -158,12 +158,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     asset[@"height"] = @(image.size.height);
     
     if(phAsset){
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        [formatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
-        [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-        NSString *creationDate = [formatter stringFromDate:phAsset.creationDate];
-        
-        asset[@"timestamp"] = creationDate;
+        asset[@"timestamp"] = [self getDateTimeInUTC:phAsset.creationDate];
         asset[@"id"] = phAsset.localIdentifier;
         // Add more extra data here ...
     }
@@ -204,19 +199,29 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
 
     NSMutableDictionary *asset = [[NSMutableDictionary alloc] init];
+    CGSize dimentions = [ImagePickerUtils getVideoDimensionsFromUrl:videoDestinationURL];
     asset[@"fileName"] = fileName;
     asset[@"duration"] = [NSNumber numberWithDouble:CMTimeGetSeconds([AVAsset assetWithURL:videoDestinationURL].duration)];
     asset[@"uri"] = videoDestinationURL.absoluteString;
     asset[@"type"] = [ImagePickerUtils getFileTypeFromUrl:videoDestinationURL];
     asset[@"fileSize"] = [ImagePickerUtils getFileSizeFromUrl:videoDestinationURL];
+    asset[@"width"] = @(dimentions.width);
+    asset[@"height"] = @(dimentions.height);
 
-    if (phAsset) {
-      asset[@"id"] = phAsset.localIdentifier;
-      // Add more extra data here ...
+    if(phAsset){
+        asset[@"timestamp"] = [self getDateTimeInUTC:phAsset.creationDate];
+        asset[@"id"] = phAsset.localIdentifier;
+        // Add more extra data here ...
     }
 
-    
     return asset;
+}
+
+- (NSString *) getDateTimeInUTC:(NSDate *)date {
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+    return [formatter stringFromDate:date];
 }
 
 - (void)checkCameraPermissions:(void(^)(BOOL granted))callback

--- a/ios/ImagePickerUtils.h
+++ b/ios/ImagePickerUtils.h
@@ -15,6 +15,8 @@
 
 + (UIImage*)resizeImage:(UIImage*)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight;
 
++ (CGSize)getVideoDimensionsFromUrl:(NSURL *)url;
+
 + (NSString *) getFileTypeFromUrl:(NSURL *)url;
 
 + (NSString *) getFileSizeFromUrl:(NSURL *)url;

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -124,6 +124,18 @@
     return [NSNumber numberWithLong:fileSize];
 }
 
++ (CGSize)getVideoDimensionsFromUrl:(NSURL *)url {
+    AVURLAsset *asset = [AVURLAsset URLAssetWithURL:url options:nil];
+    NSArray *tracks = [asset tracksWithMediaType:AVMediaTypeVideo];
+    
+    if ([tracks count] > 0) {
+        AVAssetTrack *track = [tracks objectAtIndex:0];
+        return track.naturalSize;
+    }
+    
+    return CGSizeMake(0, 0);
+}
+
 + (UIImage*)resizeImage:(UIImage*)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight
 {
     if ((maxWidth == 0) || (maxHeight == 0)) {


### PR DESCRIPTION
Added the following properties to both Android and iOS for video:

- Added datetime (timestamp) to be returned for videos on iOS and Android.
- Added width/height (dimensions) to be returned for video on iOS and Android.

NOTE: I introduced and ImageMetadata class and a Metadata parent class which can be used to extend metadata on images and videos going forward, and should make it easier to add stuff such as returning `long`/`lat`. Will follow up this work sometime in the future and move stuff like Image orientation / dimensions to be accessed via the Exif class.

Tested on our production application both iOS and Android.