### PR TITLE
Add `cookedFileName`, to give `fileName` with extension when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | fileSize  | OK  | OK      | The file size                                                                                                                                                                                                                |
 | type      | OK  | OK      | The file type (photos only)                                                                                                                                                                                                                |
 | fileName  | OK  | OK      | The file name   
+| cookedFileName  | OK  | OK      |  Like `fileName`, but probably better. It has an appropriate filename extension, if found (based on the MIME type in `type`), and if `fileName` doesn't already have an extension.
 | duration  | OK  | OK      | The selected video duration in seconds
 | bitrate   | --- | OK      | The average bitrate (in bits/sec) of the selected video, if available. (Android only)
 | timestamp | OK  | OK      | Timestamp of the photo. Only included if 'includeExtra' is true

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@react-native-community/bob": "0.17.1",
     "@semantic-release/git": "9.0.0",
+    "@types/mime": "^2.0.3",
     "@types/react": "16.9.54",
     "@types/react-native": "0.63.30",
     "semantic-release": "17.3.0",
@@ -58,5 +59,8 @@
     "targets": [
       "typescript"
     ]
+  },
+  "dependencies": {
+    "mime": "^3.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {NativeModules} from 'react-native';
+import mime from 'mime/lite';
 
-import {CameraOptions, ImageLibraryOptions, Callback, ImagePickerResponse} from './types';
+import {Asset, CameraOptions, ImageLibraryOptions, Callback, ImagePickerResponse} from './types';
 export * from './types';
 
 const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
@@ -17,11 +18,44 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   includeExtra: false,
 };
 
+function withCookedFileName(asset: Asset): Asset {
+  const unchanged = () => ({ ...asset, cookedFileName: asset.fileName });
+
+  const { type, fileName } = asset;
+  if (type == null || fileName == null) {
+    // Not enough data
+    // TODO: Can remove this condition if `Asset.type` and `Asset.fileName`
+    //   become non-optional.
+    return unchanged();
+  }
+  if (/.\..+$/.test(fileName)) {
+    // Already has an extension
+    return unchanged();
+  }
+  // An extension can't in general be extracted directly from a MIME-type
+  // string; we need a data source. See
+  //   https://github.com/react-native-image-picker/react-native-image-picker/pull/1881#issuecomment-992034446
+  //   https://www.npmjs.com/package/mime#user-content-lite-version
+  const extension = mime.getExtension(type);
+  if (extension == null) {
+    // Appropriate extension not found
+    return unchanged();
+  }
+  return {
+    ...asset,
+    cookedFileName: `${fileName}.${extension}`,
+  };
+}
+
 export function launchCamera(options: CameraOptions, callback?: Callback) : Promise<ImagePickerResponse> {
   return new Promise(resolve => {
     NativeModules.ImagePickerManager.launchCamera(
       {...DEFAULT_OPTIONS, ...options},
-      (result: ImagePickerResponse) => {
+      (rawResult: ImagePickerResponse) => {
+        const result = {
+          ...rawResult,
+          assets: rawResult.assets?.map(asset => withCookedFileName(asset)),
+        };
         if(callback) callback(result);
         resolve(result);
       },
@@ -36,7 +70,11 @@ export function launchImageLibrary(
   return new Promise(resolve => {
     NativeModules.ImagePickerManager.launchImageLibrary(
       {...DEFAULT_OPTIONS, ...options},
-      (result: ImagePickerResponse) => {
+      (rawResult: ImagePickerResponse) => {
+        const result = {
+          ...rawResult,
+          assets: rawResult.assets?.map(asset => withCookedFileName(asset)),
+        };
         if(callback) callback(result);
         resolve(result);
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Asset {
   fileSize?: number;
   type?: string;
   fileName?: string;
+  cookedFileName?: string; // TODO(breaking): Put this value at fileName
   duration?: number;
   bitrate?: number;
   timestamp?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,6 +1350,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/mime@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
+  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+
 "@types/minimist@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
@@ -4018,6 +4023,11 @@ mime@^2.4.3:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
An alternative to #1881, described at https://github.com/react-native-image-picker/react-native-image-picker/pull/1881#issuecomment-991418749.

I understand from https://github.com/react-native-image-picker/react-native-image-picker/pull/1881#issuecomment-992362255 that we're thinking of leaving out this fix, to keep the library lean. I wanted to offer this implementation, to show that it doesn't need a very large amount of code or complexity. If you're interested in looking over the proposed code/docs changes, I'd also appreciate some eyes on the commit message. Thanks! 🙂