### PR TITLE
fix(videos): videos not working on iOS 13 and throwing a fatal crash when selected

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -197,7 +197,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             [fileManager copyItemAtURL:url toURL:videoDestinationURL error:error];
           }
 
-          if (error) {
+          if (error && *error) {
               return nil;
           }
         }
@@ -352,8 +352,11 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         } else {
             NSError *error;
             NSDictionary *videoAsset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] phAsset:asset error:&error];
+                        
             if (videoAsset == nil) {
-                self.callback(@[@{@"errorCode": errOthers, @"errorMessage":  error.localizedFailureReason}]);
+                NSString *errorMessage = error.localizedFailureReason;
+                if (errorMessage == Nil) errorMessage = @"Video asset not found";
+                self.callback(@[@{@"errorCode": errOthers, @"errorMessage": errorMessage}]);
                 return;
             }
             [assets addObject:videoAsset];

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -355,7 +355,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
                         
             if (videoAsset == nil) {
                 NSString *errorMessage = error.localizedFailureReason;
-                if (errorMessage == Nil) errorMessage = @"Video asset not found";
+                if (errorMessage == nil) errorMessage = @"Video asset not found";
                 self.callback(@[@{@"errorCode": errOthers, @"errorMessage": errorMessage}]);
                 return;
             }


### PR DESCRIPTION
## Motivation (required)

Fixes #1742 where the app crashes on iOS 13 when picking a video.

Did some additional investigation on this issue to the cause and additionally into why it caused a fatal crash and found two things. 

1. On iOS 13.5 a NSError is set to the error variable `moveItemAtURL` while on iOS 14+, the error is set to Nil. The current check on the error `if (error)` matches incorrectly and ends up returning nil from the function when it should instead proceed. The original PR for this issue corrected this conditional error check. 

2. The part of this issue that resulted in a fatal crash to the app is because the `self.callback` method requires an "errorMessage", which in the particular path resulted in the error of `error.localizedFailureReason` being nil. The React Native error handler threw errors `attempt to insert nil object from objects[1]` and then `Terminating app due to uncaught exception NSInvalidArgumentException'.

### The Fix

The fix in this PR adds the additional error conditional check for nil around copying video. For the fatal crash, the fix also  includes error message handling to prevent a hard crash on the error callback when `localizedFailureReason` in not available.

## Test Plan (required)

1. To test the error handling around the fatal crash, remove the `&& *error` conditional check in the PR, but keep the error handling message fix to allow the error callback to be called. On iOS 13, you should see an error being returned in the javascript output.

2. To test the full fix on iOS 13, upload a video and see the expected results in the example app output.

3. To make sure iOS 14+ still works, run the app on iOS 14 or 15 and verify uploading a video results in the expected output in the example app.
