### PR TITLE
fix(timezone): mismatch in date from photo in system vs date returned…

### DIFF
--- a/android/src/main/java/com/imagepicker/Metadata.java
+++ b/android/src/main/java/com/imagepicker/Metadata.java
@@ -7,7 +7,6 @@ import androidx.annotation.Nullable;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 abstract class Metadata {
   protected String datetime;
@@ -30,7 +29,6 @@ abstract class Metadata {
     try {
       Date datetime = new SimpleDateFormat(format, Locale.US).parse(value);
       SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
-      formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 
       if (datetime != null) {
         return formatter.format(datetime);

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -219,7 +219,6 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
 - (NSString *) getDateTimeInUTC:(NSDate *)date {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
     [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
     return [formatter stringFromDate:date];
 }


### PR DESCRIPTION
Issue with date formatting where timezone was being set and returning the incorrect date from the library i.e `Mon Jan 17 21:12:50 2022` would be transformed into `2022-01-18T02:12:50.470+0000` (January 18th) effectively returning the wrong date from the library. I conclude, that we should leave any timezone transformation to the consumer as there are times where the consuming application needs the date with timezone data.

The library will now return with timezone data in the string i.e. `2022-01-17T21:12:50.470-0500` (January 17th)