### PR TITLE
fix ios illegal callback invocation from navite module

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -30,6 +30,9 @@
 NSString *errCameraUnavailable = @"camera_unavailable";
 NSString *errPermission = @"permission";
 NSString *errOthers = @"others";
+
+BOOL photoSelected = NO;
+
 RNImagePickerTarget target;
 
 RCT_EXPORT_MODULE();
@@ -45,6 +48,7 @@ RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSend
 RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
     target = library;
+    photoSelected = NO;
     dispatch_async(dispatch_get_main_queue(), ^{
         [self launchImagePicker:options callback:callback];
     });
@@ -401,6 +405,11 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
 - (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results API_AVAILABLE(ios(14))
 {
+    if (photoSelected == YES) {
+        return;
+    }
+    photoSelected = YES;
+
     [picker dismissViewControllerAnimated:YES completion:nil];
 
     if (results.count == 0) {


### PR DESCRIPTION
fix "illegal callback invocation from navite module" when launchImageLibrary and user tap twice on photo before PickerViewController close

## Motivation (required)

this simple change should fix ios "illegal callback invocation from navite module" error like describe in some issues like [this](https://github.com/react-native-image-picker/react-native-image-picker/issues/1532) 

In my case it could happen when user repeat photo select while PickerViewController opened

## Test Plan (required)

1) run app
2) call launchImageLibrary
3) quickly select photo multiple times until PickerViewController is closed
4) repeat launchImageLibrary call and photo select to make sure re-openings work as expected

Feel free to discuss and improve this change
