### PR TITLE
fix(live-photos): issue with non-existent file path when copying live photos with ID com.apple.private.live-photo-bundle

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -427,7 +427,8 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
         if ([provider canLoadObjectOfClass:[UIImage class]]) {
             NSString *identifier = provider.registeredTypeIdentifiers.firstObject;
-            if ([identifier isEqualToString:@"com.apple.live-photo-bundle"]) {
+            // Matches both com.apple.live-photo-bundle and com.apple.private.live-photo-bundle
+            if ([identifier containsString:@"live-photo-bundle"]) {
                 // Handle live photos
                 identifier = @"public.jpeg";
             }


### PR DESCRIPTION
There was an issue causing file not to be copied over to the temp directory which we have seen in Sentry for a while in out application i.e. `File 'file:///var/mobile/Containers/Data/Application/A7CB430B-F16F-47FC-8EEC-D63C95D867F9/tmp/F42EBD2C-F353-4289-A5D3-4879294BFA0B.jpg' does not exist.`. This was because apple was returning the following ID for some Live Photos `com.apple.private.live-photo-bundle` (not sure why this was the case as I was unable to detect any clear pattern) and we were not handling photos with that ID.

On other note if NSData / Image is null after running `loadFileRepresentationForTypeIdentifier` we should really be throwing an error, but that can a follow up PR.

This PR should catch all IDs which contain `live-photo-bundle`.

Closes #1905 #1836 (maybe more 🤷‍♂️)