### PR TITLE
fix(android): actions being saved when open launchImageLibrary

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -152,7 +152,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         }
 
         try {
-            currentActivity.startActivityForResult(Intent.createChooser(libraryIntent, null), requestCode);
+            currentActivity.startActivityForResult(libraryIntent, requestCode);
         } catch (ActivityNotFoundException e) {
             callback.invoke(getErrorMap(errOthers, e.getMessage()));
             this.callback = null;


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

What existing problem does the pull request solve?

Action popup always show when picking up an image.
When two or more image library apps are installed in users device, then this action popup contains those apps and ask us which one to use. Normally Android takes care of this and asks if you want to save your option. 
Function `createChooser` always enforces this action to being taken.

Here is an example of it 
<img width="378" alt="Screenshot 2022-01-25 at 23 53 29" src="https://user-images.githubusercontent.com/51513565/151388254-9c7e7137-9649-47a8-93c4-d356950058dd.png">

And here is how it gets when removing `createChooser` function 
<img width="383" alt="Screenshot 2022-01-27 at 15 17 55" src="https://user-images.githubusercontent.com/51513565/151388457-bebedc0e-d8c7-486b-b38c-95d365eb428a.png">
