### PR TITLE
fix(1944): fix runtime exceptions in ImagePickerModule

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -181,8 +181,14 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
             if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) {
                 deleteFile(fileUri);
             }
-            callback.invoke(getCancelMap());
-            return;
+            try {
+              callback.invoke(getCancelMap());
+              return;
+            } catch (RuntimeException exception) {
+              callback.invoke(getErrorMap(errOthers, exception.getMessage()));
+            } finally {
+              callback = null;
+            }
         }
 
         switch (requestCode) {

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -32,6 +32,8 @@ NSString *errPermission = @"permission";
 NSString *errOthers = @"others";
 RNImagePickerTarget target;
 
+BOOL photoSelected = NO;
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
@@ -45,6 +47,7 @@ RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSend
 RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
     target = library;
+    photoSelected = NO;
     dispatch_async(dispatch_get_main_queue(), ^{
         [self launchImagePicker:options callback:callback];
     });
@@ -344,6 +347,11 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         NSMutableArray<NSDictionary *> *assets = [[NSMutableArray alloc] initWithCapacity:1];
         PHAsset *asset = nil;
 
+        if (photoSelected == YES) {
+           return;
+        }
+        photoSelected = YES;
+
         // If include extra, we fetch the PHAsset, this required library permissions
         if([self.options[@"includeExtra"] boolValue]) {
           asset = [ImagePickerUtils fetchPHAssetOnIOS13:info];
@@ -403,6 +411,11 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 {
     [picker dismissViewControllerAnimated:YES completion:nil];
 
+    if (photoSelected == YES) {
+        return;
+    }
+    photoSelected = YES;
+    
     if (results.count == 0) {
         dispatch_async(dispatch_get_main_queue(), ^{
             self.callback(@[@{@"didCancel": @YES}]);


### PR DESCRIPTION
## Motivation (required)

We have noticed several crashes due to a RuntimeException for our App on multiple Android devices. The StackTrace given in the Playstore console is as follows.

```
java.lang.RuntimeException:
at android.app.ActivityThread.deliverResults (ActivityThread.java:5471)
at android.app.ActivityThread.handleSendResult (ActivityThread.java:5512)
at android.app.servertransaction.ActivityResultItem.execute (ActivityResultItem.java:51)
at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:149)
at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:103)
at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2386)
at android.os.Handler.dispatchMessage (Handler.java:107)
at android.os.Looper.loop (Looper.java:213)
at android.app.ActivityThread.main (ActivityThread.java:8178)
at java.lang.reflect.Method.invoke (Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:513)
at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1101)
Caused by: java.lang.RuntimeException:
at com.facebook.react.bridge.CallbackImpl.invoke (CallbackImpl.java:26)
at com.imagepicker.ImagePickerModule.onActivityResult (ImagePickerModule.java:184)
at com.facebook.react.bridge.ReactContext.onActivityResult (ReactContext.java:333)
at com.facebook.react.ReactInstanceManager.onActivityResult (ReactInstanceManager.java:785)
at com.facebook.react.ReactDelegate.onActivityResult (ReactDelegate.java:90)
at com.facebook.react.ReactActivityDelegate.onActivityResult (ReactActivityDelegate.java:113)
at com.facebook.react.ReactActivity.onActivityResult (ReactActivity.java:70)
at android.app.Activity.dispatchActivityResult (Activity.java:8413)
at android.app.ActivityThread.deliverResults (ActivityThread.java:5464)
```

We catch the runtime exception and return it via callback.invoke(getErrorMap(errOthers, exception.getMessage())) back to the app where we are able to take further actions and prevent a hard crash.

In an older version of react-native-image-picker there was a problem in the same module when the user clicked inside the image picker multiple times which caused the callback to be invoked multiple times. This causes another RuntimeException, thrown in CallbackImpl ("throw new RuntimeException("Illegal callback invocation from native module. This callback type only permits a single invocation from native code.").

In the current version we can reproduce the double invocation bug. We fixed this as well.

## Test Plan (required)

We are only able to reproduce the bug on iOS.

Steps to reproduce:

1. Open ImagePicker
2. Quickly tab on the same image

Result pre fix: "Illegal callback invocation from native module. This callback type only permits a single invocation from native code."

Post fix: no exception occurs.

For Android, we simply throwed a RuntimeException at the same line of code which the Stacktrace in the Playstore console provided and checked if we can now catch it in our react-native application after our fix.


