### PR TITLE
Update types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface ImagePickerResponse {
   errorCode?: ErrorCode;
   errorMessage?: string;
   assets?: Asset[];
+  uri?: string;
 }
 
 export type PhotoQuality =


### PR DESCRIPTION
on iOS devices, the `ImagePickerResponse` object contains a uri field if only one picture is taken directly from the camera. TypeScript flags this as an error since no uri type currently exists on the `ImagePickerResponse`.  

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
