### PR TITLE
feat: add new PhotoPicker API for Android 13 Teramisu

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,19 +81,19 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Options
 
-| Option         | iOS | Android | Description                                                                                                                               |
-| -------------- | --- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| mediaType      | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video)                                     |
-| maxWidth       | OK  | OK      | To resize the image                                                                                                                       |
-| maxHeight      | OK  | OK      | To resize the image                                                                                                                       |
-| videoQuality   | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                             |
-| durationLimit  | OK  | OK      | Video max duration in seconds                                                                                                             |
-| quality        | OK  | OK      | 0 to 1, photos                                                                                                                            |
-| cameraType     | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                            |
-| includeBase64  | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                         |                                                   |
-| includeExtra   | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                      |
-| saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
-| selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
+| Option            | iOS | Android | Description                                                                                                                                                               |
+| ----------------- | --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| mediaType         | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video)                                                                     |
+| maxWidth          | OK  | OK      | To resize the image                                                                                                                                                       |
+| maxHeight         | OK  | OK      | To resize the image                                                                                                                                                       |
+| videoQuality      | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                                                             |
+| durationLimit     | OK  | OK      | Video max duration in seconds                                                                                                                                             |
+| quality           | OK  | OK      | 0 to 1, photos                                                                                                                                                            |
+| cameraType        | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                                                            |
+| includeBase64     | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                                                         |     |
+| includeExtra      | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                                                      |
+| saveToPhotos      | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                                                      |
+| selectionLimit    | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 & Android version >= 13 support `0` and also it supports providing any integer value         |
 | presentationStyle | OK  | NO      | Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
 
 ## The Response Object
@@ -107,19 +107,19 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Asset Object
 
-| key       | iOS | Android | Photo/Video | Requires Permissions | Description               |
-| --------- | --- | ------- | ----------- | -------------------- | ------------------------- |
-| base64    | OK  | OK      | PHOTO ONLY  | NO                   | The base64 string of the image (photos only) |
+| key       | iOS | Android | Photo/Video | Requires Permissions | Description                                                                                                                                                                                                                                |
+| --------- | --- | ------- | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| base64    | OK  | OK      | PHOTO ONLY  | NO                   | The base64 string of the image (photos only)                                                                                                                                                                                               |
 | uri       | OK  | OK      | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
-| width     | OK  | OK      | BOTH        | NO                   | Asset dimensions                |
-| height    | OK  | OK      | BOTH        | NO                   | Asset dimensions                |
-| fileSize  | OK  | OK      | BOTH        | NO                   | The file size                                 |
-| type      | OK  | OK      | BOTH        | NO                   | The file type                                 |
-| fileName  | OK  | OK      | BOTH        | NO                   | The file name                                 |
-| duration  | OK  | OK      | VIDEO ONLY  | NO                   | The selected video duration in seconds        |
-| bitrate   | --- | OK      | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only) |
-| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true |
-| id        | OK  | OK      | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName |
+| width     | OK  | OK      | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                           |
+| height    | OK  | OK      | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                           |
+| fileSize  | OK  | OK      | BOTH        | NO                   | The file size                                                                                                                                                                                                                              |
+| type      | OK  | OK      | BOTH        | NO                   | The file type                                                                                                                                                                                                                              |
+| fileName  | OK  | OK      | BOTH        | NO                   | The file name                                                                                                                                                                                                                              |
+| duration  | OK  | OK      | VIDEO ONLY  | NO                   | The selected video duration in seconds                                                                                                                                                                                                     |
+| bitrate   | --- | OK      | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only)                                                                                                                                                      |
+| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true                                                                                                                                                                            |
+| id        | OK  | OK      | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName                                                                                                                                                           |
 
 ## Note on file storage
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion "android-Tiramisu"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        targetSdkVersion "Tiramisu"
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +21,5 @@ android {
 dependencies {
     implementation "com.facebook.react:react-native:+"
     implementation "androidx.core:core:1.3.1"
-    implementation "androidx.exifinterface:exifinterface:1.3.1"
+    implementation "androidx.exifinterface:exifinterface:1.3.3"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion "android-Tiramisu"
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion "Tiramisu"
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -127,26 +127,39 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         Intent libraryIntent;
         requestCode = REQUEST_LAUNCH_LIBRARY;
 
-        boolean isSingleSelect = this.options.selectionLimit == 1;
+        int selectionLimit = this.options.selectionLimit;
+        boolean isSingleSelect = selectionLimit == 1;
         boolean isPhoto = this.options.mediaType.equals(mediaTypePhoto);
         boolean isVideo = this.options.mediaType.equals(mediaTypeVideo);
 
-        if(isSingleSelect && (isPhoto || isVideo)) {
-            libraryIntent = new Intent(Intent.ACTION_PICK);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            if (isSingleSelect && (isPhoto || isVideo)) {
+                libraryIntent = new Intent(Intent.ACTION_PICK);
+            } else {
+                libraryIntent = new Intent(Intent.ACTION_GET_CONTENT);
+                libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+            }
         } else {
-            libraryIntent = new Intent(Intent.ACTION_GET_CONTENT);
-            libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+            libraryIntent = new Intent(MediaStore.ACTION_PICK_IMAGES);
         }
 
-        if(!isSingleSelect) {
-            libraryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        if (!isSingleSelect) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                libraryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+            } else {
+                if (selectionLimit != 1) {
+                    int maxNum = selectionLimit;
+                    if (selectionLimit == 0) maxNum = MediaStore.getPickImagesMaxLimit();
+                    libraryIntent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, maxNum);
+                }
+            }
         }
 
-        if(isPhoto) {
+        if (isPhoto) {
             libraryIntent.setType("image/*");
         } else if (isVideo) {
             libraryIntent.setType("video/*");
-        } else {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             libraryIntent.setType("*/*");
             libraryIntent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
         }

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -43,7 +43,11 @@ public class VideoMetadata extends Metadata {
       this.height = bitmap.getHeight();
     }
 
-    metadataRetriever.release();
+    try {
+      metadataRetriever.release();
+    } catch (IOException e) {
+      Log.e("VideoMetadata", "IO error releasing metadataRetriever", e);
+    }
   }
 
   public int getBitrate() {


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Android 13 (codenamed Teramisu) introduces a new [Photo Picker AP](https://developer.android.com/about/versions/13/features/photopicker)I that doesn't require the app to access full media libraries. Going forward, the photo picker will be the recommended way to access the user’s photos and videos. It also provides the API to select a specific amount of image/video to be selected instead of any number.

## Test Plan (required)

- Follow [the doc](https://developer.android.com/about/versions/13/get) to setup Android 13 emulator
- Click Select Image, Select Video or mixed, and check if it pop up the new Photo picker UI
- Play with `0`, `1` and `3` values for `selectionLimit` to see if it correctly handles max, one and certain amount of limit cases.
- Test the same thing with Android < 13 device

(Currently there is known bug where Android 13 emulator does not return correct SDK_INT, so you might need to remove the if/else check for OS version to test it)

*NOTE: It might be too early to merge this PR, this is just a preemptive PR so that we can polish this and merge when Android 13 become stable*
