### PR TITLE
feat(ios): add presentationStyle option on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | includeExtra   | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                      |
 | saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
 | selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
+| presentationStyle | OK  | NO      | Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
 
 ## The Response Object
 

--- a/ios/ImagePickerManager.h
+++ b/ios/ImagePickerManager.h
@@ -1,10 +1,30 @@
 #import <React/RCTBridgeModule.h>
 #import <UIKit/UIKit.h>
+#import <React/RCTConvert.h>
 
 typedef NS_ENUM(NSInteger, RNImagePickerTarget) {
   camera = 1,
   library
 };
+
+@implementation RCTConvert(PresentationStyle)
+
+// see: https://developer.apple.com/documentation/uikit/uimodalpresentationstyle?language=objc
+RCT_ENUM_CONVERTER(
+    UIModalPresentationStyle,
+    (@{
+      @"currentContext": @(UIModalPresentationCurrentContext),
+      @"fullScreen": @(UIModalPresentationFullScreen),
+      @"pageSheet": @(UIModalPresentationPageSheet),
+      @"formSheet": @(UIModalPresentationFormSheet),
+      @"popover": @(UIModalPresentationPopover),
+      @"overFullScreen": @(UIModalPresentationOverFullScreen),
+      @"overCurrentContext": @(UIModalPresentationOverCurrentContext)
+    }),
+    UIModalPresentationCurrentContext,
+    integerValue)
+
+@end
 
 @interface ImagePickerManager : NSObject <RCTBridgeModule>
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -67,6 +67,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
             PHPickerConfiguration *configuration = [ImagePickerUtils makeConfigurationFromOptions:options target:target];
             PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
             picker.delegate = self;
+            picker.modalPresentationStyle = [RCTConvert UIModalPresentationStyle:options[@"presentationStyle"]];
             picker.presentationController.delegate = self;
 
             if([self.options[@"includeExtra"] boolValue]) {

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -43,7 +43,7 @@
         picker.mediaTypes = @[(NSString *)kUTTypeImage, (NSString *)kUTTypeMovie];
     }
 
-    picker.modalPresentationStyle = UIModalPresentationCurrentContext;
+    picker.modalPresentationStyle = [RCTConvert UIModalPresentationStyle:options[@"presentationStyle"]];
 }
 
 + (PHPickerConfiguration *)makeConfigurationFromOptions:(NSDictionary *)options target:(RNImagePickerTarget)target API_AVAILABLE(ios(14))

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   saveToPhotos: false,
   durationLimit: 0,
   includeExtra: false,
+  presentationStyle: 'pageSheet'
 };
 
 export function launchCamera(options: CameraOptions, callback?: Callback) : Promise<ImagePickerResponse> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,14 @@ export interface ImageLibraryOptions {
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
   includeExtra?: boolean;
+  presentationStyle?:
+    | 'currentContext'
+    | 'fullScreen'
+    | 'pageSheet'
+    | 'formSheet'
+    | 'popover'
+    | 'overFullScreen'
+    | 'overCurrentContext';
 }
 
 export interface CameraOptions


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Resolves #1820. Support to show fullscreen view in iOS.

## Test Plan (required)

**Default (`presentationStyle: 'pageSheet'`):**  

<img width="300" alt="Default" src="https://user-images.githubusercontent.com/37284154/160231989-7de2b5d4-9990-4e4f-bf68-3e1ee734a562.png">


**Fullscreen view (`presentationStyle: 'fullScreen'`):**

<img width="300" alt="Fullscreen" src="https://user-images.githubusercontent.com/37284154/160231917-f15b8dbc-fdc8-48d2-8217-e7e5bee3e334.png">