### PR TITLE
fix: let multi-selection return assets in a consistent order on ios

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -412,8 +412,11 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
     dispatch_group_t completionGroup = dispatch_group_create();
     NSMutableArray<NSDictionary *> *assets = [[NSMutableArray alloc] initWithCapacity:results.count];
+    for (int i = 0; i < results.count; i++) {
+        [assets addObject:(NSDictionary *)[NSNull null]];
+    }
 
-    for (PHPickerResult *result in results) {
+    [results enumerateObjectsUsingBlock:^(PHPickerResult *result, NSUInteger index, BOOL *stop) {
         PHAsset *asset = nil;
         NSItemProvider *provider = result.itemProvider;
 
@@ -437,24 +440,27 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
                 NSData *data = [[NSData alloc] initWithContentsOfURL:url];
                 UIImage *image = [[UIImage alloc] initWithData:data];
                 
-                [assets addObject:[self mapImageToAsset:image data:data phAsset:asset]];
+                assets[index] = [self mapImageToAsset:image data:data phAsset:asset];
                 dispatch_group_leave(completionGroup);
             }];
         } else if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeMovie]) {
             [provider loadFileRepresentationForTypeIdentifier:(NSString *)kUTTypeMovie completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
-                [assets addObject:[self mapVideoToAsset:url phAsset:asset error:nil]];
+                NSDictionary *mappedAsset = [self mapVideoToAsset:url phAsset:asset error:nil];
+                if (nil != mappedAsset) {
+                    assets[index] = mappedAsset;
+                }
                 dispatch_group_leave(completionGroup);
             }];
         } else {
             // The provider didn't have an item matching photo or video (fails on M1 Mac Simulator)
             dispatch_group_leave(completionGroup);
         }
-    }
+    }];
 
     dispatch_group_notify(completionGroup, dispatch_get_main_queue(), ^{
-        //  mapVideoToAsset can fail and return nil.
+        //  mapVideoToAsset can fail and return nil, leaving asset NSNull.
         for (NSDictionary *asset in assets) {
-            if (nil == asset) {
+            if ([asset isEqual:[NSNull null]]) {
                 self.callback(@[@{@"errorCode": errOthers}]);
                 return;
             }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

On ios, when users select multiple images, this library seems to return array of assets in a random order.
As the PHPickerViewController API preserves the user selection order, it is preferred to keep the order consistent also in this library.

## Test Plan (required)

Current behavior. It does not preserve the user selection order.

https://user-images.githubusercontent.com/25456520/163591074-0a3ba496-e608-47eb-887f-4c0303100cc6.mov

Fixed behavior. It preserves the user selection order.

https://user-images.githubusercontent.com/25456520/163591140-e1e22ebb-eb2f-46f0-9d56-942df9e144c6.mov