### PR TITLE
fix: remove original image file after resizing image

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -206,6 +206,9 @@ public class Utils {
             OutputStream os = context.getContentResolver().openOutputStream(Uri.fromFile(file));
             b.compress(getBitmapCompressFormat(mimeType), options.quality, os);
             setOrientation(file, originalOrientation, context);
+
+            deleteFile(uri);
+
             return Uri.fromFile(file);
 
         } catch (Exception e) {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)
fix issue - https://github.com/react-native-image-picker/react-native-image-picker/issues/1934

## Test Plan (required)
After this small fix, in cache folder exist only one resized image.

![gnome-shell-screenshot-5jtqa4](https://user-images.githubusercontent.com/12866266/164959413-e1f2fe8c-d3d7-4cfe-8cc1-057386d8955b.png)
