### PR TITLE
fix(1977): fix reset photo selected on ios

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -39,6 +39,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
     target = camera;
+    photoSelected = NO;
     dispatch_async(dispatch_get_main_queue(), ^{
         [self launchImagePicker:options callback:callback];
     });


### PR DESCRIPTION
## Motivation (required)

This PR fixes a bug described in [#1977 ]. This bug was introduced in [this PR](https://github.com/react-native-image-picker/react-native-image-picker/pull/1948).

The variable `photoSelected` was never reset in the case of the function `launchCamera` as it was with the function `launchImageLibrary`.

This issue causes the function `launchCamera` to never resolve on the second call. This PR fixes this.

## Test Plan (required)

Steps to reproduce:

Execute the following twice.

1. Call `launchCamera` and select an image.
2. Console.log the resolved promise either using await or a promise chain.

Prior fix:

- The promise is resolved on first `launchCamera`
- The promise is not resolve on second `launchCamera`

Post fix:
`launchCamera` does resolve as expected on second call (or on every subsequent call of course).

Everything works as expected. The bugs that are resolved in [this PR](https://github.com/react-native-image-picker/react-native-image-picker/pull/1948) are still fixed. The bug in [#1977 ] for `launchCamera` is fixed as well.

I have used the following code for my tests on an iPhone 12 real physical device.

```javascript
async function openCamera() {
    try {
        const result = await launchCamera({
              mediaType: "photo",
              quality: 0.1,
              cameraType: "back",
              includeBase64: true,
              saveToPhotos: true,
         })
        console.log(result)
    } catch (error) {
        console.log(error)
    }
}

<SafeAreaView style={{margin: 20}}>
   <Pressable onPress={openCamera}
        <Text>Open camera</Text>
   </Pressable>
</SafeAreaView>
```

I have performed a regression test for `launchImageLibrary` using a similar workflow.
