### PR TITLE
BREAKING CHANGE: Use requestImageForAsset to retrieve UIImage and remove includeExtra (as it will be default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | quality        | OK  | OK      | 0 to 1, photos                                                                                                                            |
 | cameraType     | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                            |
 | includeBase64  | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                         |                                                   |
-| includeExtra   | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                      |
 | saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
 | selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
 | presentationStyle | OK  | NO      | Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
@@ -118,7 +117,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | fileName  | OK  | OK      | BOTH        | NO                   | The file name                                 |
 | duration  | OK  | OK      | VIDEO ONLY  | NO                   | The selected video duration in seconds        |
 | bitrate   | --- | OK      | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only) |
-| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true |
+| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. |
 | id        | OK  | OK      | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName |
 
 ## Note on file storage

--- a/android/src/main/java/com/imagepicker/Options.java
+++ b/android/src/main/java/com/imagepicker/Options.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 public class Options {
     int selectionLimit;
     Boolean includeBase64;
-    Boolean includeExtra;
     int videoQuality = 1;
     int quality;
     int maxWidth;
@@ -21,7 +20,6 @@ public class Options {
         mediaType = options.getString("mediaType");
         selectionLimit = options.getInt("selectionLimit");
         includeBase64 = options.getBoolean("includeBase64");
-        includeExtra = options.getBoolean("includeExtra");
 
         String videoQualityString = options.getString("videoQuality");
         if(!TextUtils.isEmpty(videoQualityString) && !videoQualityString.toLowerCase().equals("high")) {

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -404,15 +404,11 @@ public class Utils {
         map.putInt("width", dimensions[0]);
         map.putInt("height", dimensions[1]);
         map.putString("type", getMimeType(uri, context));
+        map.putString("timestamp", imageMetadata.getDateTime());
+        map.putString("id", fileName);
 
         if (options.includeBase64) {
             map.putString("base64", getBase64String(uri, context));
-        }
-
-        if(options.includeExtra) {
-          // Add more extra data here ...
-          map.putString("timestamp", imageMetadata.getDateTime());
-          map.putString("id", fileName);
         }
 
         return map;
@@ -431,12 +427,9 @@ public class Utils {
         map.putString("type", getMimeType(uri, context));
         map.putInt("width", videoMetadata.getWidth());
         map.putInt("height", videoMetadata.getHeight());
-
-        if(options.includeExtra) {
-          // Add more extra data here ...
-          map.putString("timestamp", videoMetadata.getDateTime());
-          map.putString("id", fileName);
-        }
+        map.putString("timestamp", videoMetadata.getDateTime());
+        map.putString("id", fileName);
+        // Add more extra data here ...
 
         return map;
     }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,9 +4,6 @@ import {DemoTitle, DemoButton, DemoResponse} from './components';
 
 import * as ImagePicker from 'react-native-image-picker';
 
-/* toggle includeExtra */
-const includeExtra = true;
-
 export default function App() {
   const [response, setResponse] = React.useState<any>(null);
 
@@ -82,7 +79,6 @@ const actions: Action[] = [
       saveToPhotos: true,
       mediaType: 'photo',
       includeBase64: false,
-      includeExtra,
     },
   },
   {
@@ -94,7 +90,6 @@ const actions: Action[] = [
       selectionLimit: 0,
       mediaType: 'photo',
       includeBase64: false,
-      includeExtra,
     },
   },
   {
@@ -103,7 +98,6 @@ const actions: Action[] = [
     options: {
       saveToPhotos: true,
       mediaType: 'video',
-      includeExtra,
     },
   },
   {
@@ -112,7 +106,6 @@ const actions: Action[] = [
     options: {
       selectionLimit: 0,
       mediaType: 'video',
-      includeExtra,
     },
   },
   {
@@ -121,7 +114,6 @@ const actions: Action[] = [
     options: {
       selectionLimit: 0,
       mediaType: 'mixed',
-      includeExtra,
     },
   },
 ];

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -51,12 +51,8 @@
 #if __has_include(<PhotosUI/PHPicker.h>)
     PHPickerConfiguration *configuration;
     
-    if(options[@"includeExtra"]) {
-        PHPhotoLibrary *photoLibrary = [PHPhotoLibrary sharedPhotoLibrary];
-        configuration = [[PHPickerConfiguration alloc] initWithPhotoLibrary:photoLibrary];
-    } else {
-        configuration = [[PHPickerConfiguration alloc] init];
-    }
+    PHPhotoLibrary *photoLibrary = [PHPhotoLibrary sharedPhotoLibrary];
+    configuration = [[PHPickerConfiguration alloc] initWithPhotoLibrary:photoLibrary];
     
     configuration.preferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationModeCurrent;
     configuration.selectionLimit = [options[@"selectionLimit"] integerValue];

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   selectionLimit: 1,
   saveToPhotos: false,
   durationLimit: 0,
-  includeExtra: false,
   presentationStyle: 'pageSheet'
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,6 @@ export interface ImageLibraryOptions {
   quality?: PhotoQuality;
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
-  includeExtra?: boolean;
   presentationStyle?:
     | 'currentContext'
     | 'fullScreen'


### PR DESCRIPTION
- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

This is a fix attempting to remedy issues with file copying silently failing on iOS. We have experienced over 1000+ instances reported through Sentry of files being missing after being picked. This seems to be related to some combination of Live Photos, photos which adjustments, or photos from iCloud. The issue is related to this code:

```
// Matches both com.apple.live-photo-bundle and com.apple.private.live-photo-bundle
if ([identifier containsString:@"live-photo-bundle"]) {
    // Handle live photos
    identifier = @"public.jpeg";
}
```

The updated code will handle Live Photos correctly via the [requestImageForAsset](https://developer.apple.com/documentation/photokit/phimagemanager/1616964-requestimageforasset?language=objc) method which handles photos, Live Photos and videos (as thumbnails).

## Test Plan (required)

The test plan is to use this branch in our production application for our next release. Using Sentry to determine if this reduces the frequency of the issue.

## Notes

This removes `includeExtra` and treats PHAsset as a first-class citizen, aka. it's a breaking change as to access the library on iOS 14 you would need to have library permissions. This is to simplify the API, but also a preparation for moving over more metadata to rely on PHAsset in subsequent PRs.

Fixes #1541 (for images only, not videos)
