### PR TITLE
fix(android): VideoMetadata to be compatible with Android SDK33

### DIFF
--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -43,7 +43,11 @@ public class VideoMetadata extends Metadata {
       this.height = bitmap.getHeight();
     }
 
-    metadataRetriever.release();
+    try {
+      metadataRetriever.release();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   public int getBitrate() {

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -46,7 +46,7 @@ public class VideoMetadata extends Metadata {
     try {
       metadataRetriever.release();
     } catch (IOException e) {
-      e.printStackTrace();
+      Log.e("RNIP", "IO error releasing video metadata: " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

[Android 13 hits Platform Stability](https://android-developers.googleblog.com/2022/06/android-13-beta-3-platform-stability.html) and as such apps might be interesting in updating. Updating the `compileSdkVersion` to 33 results in build errors.

## Test Plan (required)

- Pick a video from gallery
- Should work on Android SDK lower than 33
- Should work on Android SDK 33