### PR TITLE
feat(ios): add api to dismiss picker modal on ios

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -31,6 +31,7 @@ NSString *errCameraUnavailable = @"camera_unavailable";
 NSString *errPermission = @"permission";
 NSString *errOthers = @"others";
 RNImagePickerTarget target;
+UIViewController* imagePickerController;
 
 BOOL photoSelected = NO;
 
@@ -52,6 +53,18 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     dispatch_async(dispatch_get_main_queue(), ^{
         [self launchImagePicker:options callback:callback];
     });
+}
+
+RCT_EXPORT_METHOD(dismissImagePicker)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self dismiss];
+    });
+}
+
+- (void)dismiss
+{
+    [imagePickerController dismissViewControllerAnimated:NO completion:nil];
 }
 
 - (void)launchImagePicker:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback
@@ -110,6 +123,7 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 
 - (void) showPickerViewController:(UIViewController *)picker
 {
+    imagePickerController = picker;
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *root = RCTPresentedViewController();
         [root presentViewController:picker animated:YES completion:nil];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {NativeModules} from 'react-native';
+import {NativeModules, Platform} from 'react-native';
 
 import {CameraOptions, ImageLibraryOptions, Callback, ImagePickerResponse} from './types';
 export * from './types';
@@ -44,4 +44,12 @@ export function launchImageLibrary(
     );
   })
   
+}
+
+export function dismissImagePickerIOS(): void {
+  if (Platform.OS === 'android') {
+    return;
+  }
+  
+  NativeModules.ImagePickerManager.dismissImagePicker();
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

When the user runs the app where it left on presentation of image picker through a deep link, the modal of picker should be dismissed. There needs API to dismiss modal manually

## Test Plan (required)
show image picker then when the app goes background, the modal of picker is dismissed

https://user-images.githubusercontent.com/16796578/178428546-c7221b11-cd1d-45fd-8cd0-743a50e3875b.mp4

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
