### PR TITLE
fix(android): Unreported IOException on MediaMetadataRetriever.release() with target SDK 33

### DIFF
--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -43,7 +43,11 @@ public class VideoMetadata extends Metadata {
       this.height = bitmap.getHeight();
     }
 
-    metadataRetriever.release();
+    try {
+      metadataRetriever.release();
+    } catch (IOException e) {
+      Log.w("RNIP", "Could not release metadata retriever: " + e.getMessage());
+    }
   }
 
   public int getBitrate() {


### PR DESCRIPTION
## Motivation (required)

I've changed the target sdk version to 33 (Tiramisu) on my RN app, but during the build, gradle complains about the unreported IOException caused by MediaMetadataRetriever.release().

The exception was added in 33 (Tiramisu) as reported in the official docs: https://developer.android.com/reference/android/media/MediaMetadataRetriever#release()

I think that adding a try catch should be the best approach to this, so that if for whatever reason the release throws an exception (already released by system, etc), the app does not crash. I used a warn instead of an error since at that point the release is not much relevant to the functionalities (if an exception is thrown, the metadata retriever probably has been already released by the system).

## Test Plan (required)

You can test it by targetting to SDK 33 (Tiramisu) and build any app.