### PR TITLE
fix: the fileSize of the selected image is bigger than the origin one in ios

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -272,7 +272,7 @@ PODS:
   - React-jsinspector (0.66.4)
   - React-logger (0.66.4):
     - glog
-  - react-native-image-picker (4.7.3):
+  - react-native-image-picker (4.8.4):
     - React-Core
   - React-perflogger (0.66.4)
   - React-RCTActionSheet (0.66.4):
@@ -511,7 +511,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 94ce921e1d8ce7023366873ec371f3441383b396
   React-jsinspector: d0374f7509d407d2264168b6d0fad0b54e300b85
   React-logger: 933f80c97c633ee8965d609876848148e3fef438
-  react-native-image-picker: 4e6008ad8c2321622affa2c85432a5ebd02d480c
+  react-native-image-picker: cffb727cf2f59bd5c0408e30b3dbe0b935f88835
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
   React-RCTActionSheet: 7d3041e6761b4f3044a37079ddcb156575fb6d89
   React-RCTAnimation: 743e88b55ac62511ae5c2e22803d4f503f2a3a13

--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -35,10 +35,10 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>NSCameraUsageDescription</key>
 	<string>$(PRODUCT_NAME) would like to use your camera</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>$(PRODUCT_NAME) would like to your microphone (for videos)</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -89,8 +89,6 @@ const actions: Action[] = [
     title: 'Select Image',
     type: 'library',
     options: {
-      maxHeight: 200,
-      maxWidth: 200,
       selectionLimit: 0,
       mediaType: 'photo',
       includeBase64: false,


### PR DESCRIPTION

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
This PR fixes a bug described in [issue 1894](https://github.com/react-native-image-picker/react-native-image-picker/issues/1894).
the binary data returned by `UIImageJPEGRepresentation` and `UIImagePNGRepresentation` is much larger than
the original file.
this PR will use the original data first if user doesn't pass `maxWidth`, `maxHeight` and `quality`

## Test Plan (required)
prepare a image:
<img width="200" src="https://user-images.githubusercontent.com/8579651/180359502-f7abb395-e082-4865-901f-97b48e28a8ba.png" >

1. save the above png image in a device.
2. run example app in the device ( `Team` and `Bundle Identifier` may need to be configured first).
3. click `Select Image` to select the above image
4. compare `fileSize` in the screen with the value in the `Photo` ( or use `ls -l` to check the saved image size)
5. click `Take image` and compare the two values again

<img width="300" src="https://user-images.githubusercontent.com/8579651/180361668-43658f0f-fbfc-4d38-b443-e27a4c63cab0.png">

In addition,
there is an issue in the `react-native` library when used for upload,
I've provided a temporary solution [here](https://github.com/react-native-image-picker/react-native-image-picker/issues/1894#issuecomment-1191340535)