### PR TITLE
Fix mixed library picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,19 +81,19 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Options
 
-| Option         | iOS | Android | Description                                                                                                                               |
-| -------------- | --- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| mediaType      | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video)                                     |
-| maxWidth       | OK  | OK      | To resize the image                                                                                                                       |
-| maxHeight      | OK  | OK      | To resize the image                                                                                                                       |
-| videoQuality   | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                             |
-| durationLimit  | OK  | OK      | Video max duration in seconds                                                                                                             |
-| quality        | OK  | OK      | 0 to 1, photos                                                                                                                            |
-| cameraType     | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                            |
-| includeBase64  | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                         |                                                   |
-| includeExtra   | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                      |
-| saveToPhotos   | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
-| selectionLimit | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 support `0` and also it supports providing any integer value |
+| Option            | iOS | Android | Description                                                                                                                                                               |
+| ----------------- | --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| mediaType         | OK  | OK      | 'photo' or 'video' or 'mixed'(mixed supported only for launchImageLibrary, to pick an photo or video)                                                                     |
+| maxWidth          | OK  | OK      | To resize the image                                                                                                                                                       |
+| maxHeight         | OK  | OK      | To resize the image                                                                                                                                                       |
+| videoQuality      | OK  | OK      | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                                                             |
+| durationLimit     | OK  | OK      | Video max duration in seconds                                                                                                                                             |
+| quality           | OK  | OK      | 0 to 1, photos                                                                                                                                                            |
+| cameraType        | OK  | OK      | 'back' or 'front'. May not be supported in few android devices                                                                                                            |
+| includeBase64     | OK  | OK      | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                                                         |     |
+| includeExtra      | OK  | OK      | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                                                      |
+| saveToPhotos      | OK  | OK      | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                                                      |
+| selectionLimit    | OK  | OK      | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 & Android version >= 13 support `0` and also it supports providing any integer value         |
 | presentationStyle | OK  | NO      | Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
 
 ## The Response Object
@@ -107,19 +107,19 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Asset Object
 
-| key       | iOS | Android | Photo/Video | Requires Permissions | Description               |
-| --------- | --- | ------- | ----------- | -------------------- | ------------------------- |
-| base64    | OK  | OK      | PHOTO ONLY  | NO                   | The base64 string of the image (photos only) |
+| key       | iOS | Android | Photo/Video | Requires Permissions | Description                                                                                                                                                                                                                                |
+| --------- | --- | ------- | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| base64    | OK  | OK      | PHOTO ONLY  | NO                   | The base64 string of the image (photos only)                                                                                                                                                                                               |
 | uri       | OK  | OK      | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library |
-| width     | OK  | OK      | BOTH        | NO                   | Asset dimensions                |
-| height    | OK  | OK      | BOTH        | NO                   | Asset dimensions                |
-| fileSize  | OK  | OK      | BOTH        | NO                   | The file size                                 |
-| type      | OK  | OK      | BOTH        | NO                   | The file type                                 |
-| fileName  | OK  | OK      | BOTH        | NO                   | The file name                                 |
-| duration  | OK  | OK      | VIDEO ONLY  | NO                   | The selected video duration in seconds        |
-| bitrate   | --- | OK      | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only) |
-| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true |
-| id        | OK  | OK      | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName |
+| width     | OK  | OK      | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                           |
+| height    | OK  | OK      | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                           |
+| fileSize  | OK  | OK      | BOTH        | NO                   | The file size                                                                                                                                                                                                                              |
+| type      | OK  | OK      | BOTH        | NO                   | The file type                                                                                                                                                                                                                              |
+| fileName  | OK  | OK      | BOTH        | NO                   | The file name                                                                                                                                                                                                                              |
+| duration  | OK  | OK      | VIDEO ONLY  | NO                   | The selected video duration in seconds                                                                                                                                                                                                     |
+| bitrate   | --- | OK      | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only)                                                                                                                                                      |
+| timestamp | OK  | OK      | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true                                                                                                                                                                            |
+| id        | OK  | OK      | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName                                                                                                                                                           |
 
 ## Note on file storage
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +21,5 @@ android {
 dependencies {
     implementation "com.facebook.react:react-native:+"
     implementation "androidx.core:core:1.3.1"
-    implementation "androidx.exifinterface:exifinterface:1.3.1"
+    implementation "androidx.exifinterface:exifinterface:1.3.3"
 }

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -127,26 +127,39 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         Intent libraryIntent;
         requestCode = REQUEST_LAUNCH_LIBRARY;
 
-        boolean isSingleSelect = this.options.selectionLimit == 1;
+        int selectionLimit = this.options.selectionLimit;
+        boolean isSingleSelect = selectionLimit == 1;
         boolean isPhoto = this.options.mediaType.equals(mediaTypePhoto);
         boolean isVideo = this.options.mediaType.equals(mediaTypeVideo);
 
-        if(isSingleSelect && (isPhoto || isVideo)) {
-            libraryIntent = new Intent(Intent.ACTION_PICK);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            if (isSingleSelect && (isPhoto || isVideo)) {
+                libraryIntent = new Intent(Intent.ACTION_PICK);
+            } else {
+                libraryIntent = new Intent(Intent.ACTION_GET_CONTENT);
+                libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+            }
         } else {
-            libraryIntent = new Intent(Intent.ACTION_GET_CONTENT);
-            libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+            libraryIntent = new Intent(MediaStore.ACTION_PICK_IMAGES);
         }
 
-        if(!isSingleSelect) {
-            libraryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        if (!isSingleSelect) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                libraryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+            } else {
+                if (selectionLimit != 1) {
+                    int maxNum = selectionLimit;
+                    if (selectionLimit == 0) maxNum = MediaStore.getPickImagesMaxLimit();
+                    libraryIntent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, maxNum);
+                }
+            }
         }
 
-        if(isPhoto) {
+        if (isPhoto) {
             libraryIntent.setType("image/*");
         } else if (isVideo) {
             libraryIntent.setType("video/*");
-        } else {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             libraryIntent.setType("*/*");
             libraryIntent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
         }

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -165,7 +165,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         }
 
         try {
-            currentActivity.startActivityForResult(libraryIntent, requestCode);
+            currentActivity.startActivityForResult(Intent.createChooser(libraryIntent, "Select media"), requestCode);
         } catch (ActivityNotFoundException e) {
             callback.invoke(getErrorMap(errOthers, e.getMessage()));
             this.callback = null;

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -43,7 +43,11 @@ public class VideoMetadata extends Metadata {
       this.height = bitmap.getHeight();
     }
 
-    metadataRetriever.release();
+    try {
+      metadataRetriever.release();
+    } catch (IOException e) {
+      Log.e("VideoMetadata", "IO error releasing metadataRetriever", e);
+    }
   }
 
   public int getBitrate() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-picker",
-  "version": "4.8.5",
+  "version": "4.9.0",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
   "main": "src/index.ts",


### PR DESCRIPTION
## Motivation (required)
Using the `ACTION_GET_CONTENT` instead of `ACTION_PICK` when picking image/video, clicking on `Photos` (nexus) or `Gallery` (samsung) it would not propagate the event to `onActivityResult`.
This fixes that.

<img width="377" alt="image" src="https://user-images.githubusercontent.com/16626134/200444684-6fba35d0-e627-4be7-83d6-424a98462162.png">

## Test Plan (required)
Use this piece of code to open the library for image/video selection `await launchImageLibrary({mediaType: 'mixed'})` and click on `Photos` as shown in the image above than select an Image.
Before the fix it would do nothing, after the fix it selects the image and returns the response.