### PR TITLE
Change PHPicker preferredAssetRepresentationMode to Automatic

### DIFF
--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -58,7 +58,7 @@
         configuration = [[PHPickerConfiguration alloc] init];
     }
     
-    configuration.preferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationModeCurrent;
+    configuration.preferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationModeAutomatic;
     configuration.selectionLimit = [options[@"selectionLimit"] integerValue];
 
     if ([options[@"mediaType"] isEqualToString:@"video"]) {


### PR DESCRIPTION
- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
Selecting HEIC files will return the original format which is in most cases not desired.
Selecting HEIC should get us the JPEG file format.

Changing the `preferredAssetRepresentationMode` from [PHPickerConfigurationAssetRepresentationModeCurrent](https://developer.apple.com/documentation/photokit/phpickerconfigurationassetrepresentationmode/phpickerconfigurationassetrepresentationmodecurrent?language=objc) to [PHPickerConfigurationAssetRepresentationModeAutomatic](https://developer.apple.com/documentation/photokit/phpickerconfigurationassetrepresentationmode/phpickerconfigurationassetrepresentationmodeautomatic?language=objc) will automatically select the appropriate format; for heic files we will get jpeg. This is also the behaviour of `UIImagePickerController`.
 
This way we will be matching the behaviour of `PHPickerViewController` to `UIImagePickerController`.

By the way, before https://github.com/react-native-image-picker/react-native-image-picker/pull/2006 selecting HEIC files was also resulting in JPEG files but this was due to the use of the inefficient `UIImageJPEGRepresentation` conversion.
With this PR, selecting HEIC files will result in JPEG format that is provided by the iOS (no explicit conversion is done from our side)

What existing problem does the pull request solve?
https://github.com/react-native-image-picker/react-native-image-picker/issues/2052

## Test Plan (required)
The changed code is not that much and I'm not writing new code, I'm not providing a test plan for now as it does not seem to be the case where a test plan is needed, let me know if it's really required.
