### PR TITLE
correctly handle orientation on android

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -156,10 +156,20 @@ public class Utils {
 
     public static int[] getImageDimensions(Uri uri, Context reactContext) {
         try (InputStream inputStream = reactContext.getContentResolver().openInputStream(uri)) {
+
+            String orientation = getOrientation(uri,reactContext);
+
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inJustDecodeBounds = true;
             BitmapFactory.decodeStream(inputStream, null, options);
-            return new int[]{options.outWidth, options.outHeight};
+
+            if (orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_90))
+                    || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_270))) {
+                return new int[]{options.outHeight, options.outWidth};
+            }else {
+                return new int[]{options.outWidth, options.outHeight};
+            }
+
         } catch (IOException e) {
             e.printStackTrace();
             return new int[]{0, 0};

--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -162,9 +162,7 @@ public class Utils {
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inJustDecodeBounds = true;
             BitmapFactory.decodeStream(inputStream, null, options);
-
-            if (orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_90))
-                    || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_270))) {
+            if (needToSwapDimension(orientation)) {
                 return new int[]{options.outHeight, options.outWidth};
             }else {
                 return new int[]{options.outWidth, options.outHeight};
@@ -178,7 +176,7 @@ public class Utils {
 
     static boolean hasPermission(final Activity activity) {
         final int writePermission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        return writePermission == PackageManager.PERMISSION_GRANTED ? true : false;
+        return writePermission == PackageManager.PERMISSION_GRANTED;
     }
 
     static String getBase64String(Uri uri, Context reactContext) {
@@ -199,6 +197,11 @@ public class Utils {
         }
     }
 
+    private static boolean needToSwapDimension(String orientation){
+        return orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_90))
+                || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_270));
+    }
+
     // Resize image
     // When decoding a jpg to bitmap all exif meta data will be lost, so make sure to copy orientation exif to new file else image might have wrong orientations
     public static Uri resizeImage(Uri uri, Context context, Options options) {
@@ -214,9 +217,13 @@ public class Utils {
             try (InputStream imageStream = context.getContentResolver().openInputStream(uri)) {
                 String mimeType = getMimeType(uri, context);
                 Bitmap b = BitmapFactory.decodeStream(imageStream);
-
-                b = Bitmap.createScaledBitmap(b, newDimens[0], newDimens[1], true);
                 String originalOrientation = getOrientation(uri, context);
+
+                if (needToSwapDimension(originalOrientation)) {
+                    b = Bitmap.createScaledBitmap(b, newDimens[1], newDimens[0], true);
+                }else {
+                    b = Bitmap.createScaledBitmap(b, newDimens[0], newDimens[1], true);
+                }
 
                 File file = createFile(context, getFileTypeFromMime(mimeType));
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ x] Explain the **motivation** for making this change.
- [x ] Provide a **test plan** demonstrating that the code is solid.
- [x ] Match the **code formatting** of the rest of the codebase.
- [x ] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

the width / height returned by the library is swapped if the image is on portrait mode on some device (tested with Sony zx1 compact, and see also in some samsung device)

this because the library do not look on the image orientation when computing the w/h this is a problem also if the set the maxHight/Width since you are currently compare maxWidth with height and maxHeight with width

fix #1901 #1689

## Test Plan (required)

run the example app, take the photo on portrait, check that the height > width
take a photo on landscape and check that width > height
