### PR TITLE
fix(types): Define CameraOptions and ImageLibraryOptions symmetrically

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 export type Callback = (response: ImagePickerResponse) => any;
 
-export interface ImageLibraryOptions {
-  selectionLimit?: number;
+export interface OptionsCommon {
   mediaType: MediaType;
   maxWidth?: number;
   maxHeight?: number;
@@ -19,8 +18,11 @@ export interface ImageLibraryOptions {
     | 'overCurrentContext';
 }
 
-export interface CameraOptions
-  extends Omit<ImageLibraryOptions, 'selectionLimit'> {
+export interface ImageLibraryOptions extends OptionsCommon {
+  selectionLimit?: number;
+}
+
+export interface CameraOptions extends OptionsCommon {
   durationLimit?: number;
   saveToPhotos?: boolean;
   cameraType?: CameraType;


### PR DESCRIPTION
By factoring out an `interface OptionsCommon` that both interfaces extend, instead of having one extend the other minus a property. This seems cleaner, since the properties are now neatly organized into three groups:

- in common
- unique to ImageLibraryOptions
- unique to CameraOptions

This doesn't actually change either type, just how we structure their definitions, so I don't expect it to add or remove any type errors that TypeScript reports.

It also makes the TypeScript file a bit friendlier to conversion to Flow via TsFlower: https://github.com/gnprice/tsflower

-----

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

(See above)

## Test Plan (required)

Could we add a `yarn test` script that runs the TypeScript type checker? I'm not very familiar with how to operate TS (my project uses Flow for its commitment to soundness), so my test plan at this point is just to make sure CI passes.