### PR TITLE
Changed the way we detect images in iOS

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -489,7 +489,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         
         dispatch_group_enter(completionGroup);
 
-        if ([provider canLoadObjectOfClass:[UIImage class]]) {
+        if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
             NSString *identifier = provider.registeredTypeIdentifiers.firstObject;
             // Matches both com.apple.live-photo-bundle and com.apple.private.live-photo-bundle
             if ([identifier containsString:@"live-photo-bundle"]) {


### PR DESCRIPTION
- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
If you select a `.bmp` image it will fail on iOS. This is due to the fact that `canLoadObjectOfClass:[UIImage class]` is not really image universal (i.e. does not support bmp and possibly other types).

We do use `hasItemConformingToTypeIdentifier` for videos and for the old image picker. It makes sense to use it here too for the new image picker (phpicker).
___

That being said, the fix is simply to swap this line
```java
if ([provider canLoadObjectOfClass:[UIImage class]]) {
```
with
```java
if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
```

If you think the use of `canLoadObjectOfClass` is necessary we can extend the condition as follow:
```java
if ([provider canLoadObjectOfClass:[UIImage class]] || [provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
```



## Test Plan (required)
- Tested with images that were working and confirmed that they are still working after the change.
- Tested with .bmp image which was not working and now it's working.
