### PR TITLE
[android] return the 'originFilepath' when select image

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,23 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Asset Object
 
-| key       | iOS | Android | Web | Photo/Video | Requires Permissions | Description               |
-| --------- | --- | ------- | --- | ----------- | -------------------- | ------------------------- |
-| base64    | OK  | OK      | OK  | PHOTO ONLY  | NO                   | The base64 string of the image (photos only) |
-| uri       | OK  | OK      | OK  | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library. For web it uses the base64 as uri. |
-| width     | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                |
-| height    | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                |
-| fileSize  | OK  | OK      | NO  | BOTH        | NO                   | The file size                                 |
-| type      | OK  | OK      | NO  | BOTH        | NO                   | The file type                                 |
-| fileName  | OK  | OK      | NO  | BOTH        | NO                   | The file name                                 |
-| duration  | OK  | OK      | NO  | VIDEO ONLY  | NO                   | The selected video duration in seconds        |
-| bitrate   | --- | OK      | NO  | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only) |
-| timestamp | OK  | OK      | NO  | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true |
-| id        | OK  | OK      | NO  | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName |
+| key            | iOS    | Android | Web | Photo/Video | Requires Permissions | Description                                                                                                                                                                                                                                                                    |
+|----------------|--------|---------|-----|-------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| base64         | OK     | OK      | OK  | PHOTO ONLY  | NO                   | The base64 string of the image (photos only)                                                                                                                                                                                                                                   |
+| uri            | OK     | OK      | OK  | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library. For web it uses the base64 as uri. |
+| width          | OK     | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
+| height         | OK     | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
+| fileSize       | OK     | OK      | NO  | BOTH        | NO                   | The file size                                                                                                                                                                                                                                                                  |
+| type           | OK     | OK      | NO  | BOTH        | NO                   | The file type                                                                                                                                                                                                                                                                  |
+| fileName       | OK     | OK      | NO  | BOTH        | NO                   | The file name                                                                                                                                                                                                                                                                  |
+| duration       | OK     | OK      | NO  | VIDEO ONLY  | NO                   | The selected video duration in seconds                                                                                                                                                                                                                                         |
+| bitrate        | ---    | OK      | NO  | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only)                                                                                                                                                                                          |
+| timestamp      | OK     | OK      | NO  | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true                                                                                                                                                                                                                |
+| id             | OK     | OK      | NO  | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName                                                                                                                                                                                               |
+| originFilepath | **NO** | OK      | NO  | BOTH        | YES                  | thr origin file path **when select image**                                                                                                                                                                                                                                     |
+
+**waring:** the `uri` is point at a temporary file! When you pick a same image twice, it will be two different `uri`, 
+the `fileName` is the temporary file's name.
 
 ## Note on file storage
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,10 @@ export interface Asset {
   bitrate?: number;
   timestamp?: string;
   id?: string;
+  /**
+   * the origin filepath <b>when select image</b>.(android only)
+   */
+  originFilepath?: string
 }
 
 export interface ImagePickerResponse {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
Many app want to use the filename/filepath as a key to avoid their image to be upload twice or more.
But the existing module return a temporary filepath and filename, we can not distinct each image that we select!

## Test Plan (required)


[1]: In this video, I select a image twice, it returns the same `originFilepath`.


https://user-images.githubusercontent.com/72915970/216806114-b12ff6ef-d3ff-480a-afe1-c98a8db9cdb8.mp4

related test code:
```typescript
  pickerCallback(response: ImagePickerResponse) {``
    if (!response.errorCode) {
      const assets = response.assets
      if (!assets) {
        return
      }
      // show result here
      showSingleBtnTip('response', JSON.stringify(response))
      console.log(response)
    }
  }

  onSelect(index: number) {
    if (index === 0) {
      launchCamera({ mediaType: 'photo' })
        .then(this.pickerCallback)
        .catch(e => {
          Toast.show('打开相机失败: ' + e.message)
        })
        .finally(() => {
          this.drawer.current?.closeDrawer()
        })
    } else if (index === 1) {
      launchImageLibrary({ selectionLimit: 1, mediaType: 'photo' })
        .then(this.pickerCallback)
        .catch(e => {
          Toast.show('打开图库失败: ' + e.message)
        })
        .finally(() => {
          this.drawer.current?.closeDrawer()
        })
    }
  }
```


