### PR TITLE
fix: iOS launchCamera opens camera with black background (#2024)

### DIFF
--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -40,8 +40,19 @@ RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSend
 {
     target = camera;
     photoSelected = NO;
+    if ([ImagePickerUtils isSimulator]) {
+        callback(@[@{@"errorCode": errCameraUnavailable}]);
+        return;
+    }
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self launchImagePicker:options callback:callback];
+        [self checkCameraPermissions:^(BOOL granted) {
+            if (!granted) {
+                callback(@[@{@"errorCode": errPermission}]);
+            }
+            else {
+                [self launchImagePicker:options callback:callback];
+            }
+        }];
     });
 }
 
@@ -67,11 +78,6 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 - (void)launchImagePicker:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback
 {
     self.callback = callback;
-    
-    if (target == camera && [ImagePickerUtils isSimulator]) {
-        self.callback(@[@{@"errorCode": errCameraUnavailable}]);
-        return;
-    }
     
     self.options = options;
 


### PR DESCRIPTION


Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

Fixes #2024 

## Test Plan (required)

See #2024 for replication steps. Effectively, no new code has been written, but instead, code has been moved from launchImagePicker that specifically related to camera. This also fixes the issue where the camera was being launched without permission. The below image shows the result of clicking "Take Image" and not allowing the permission.
<img width="555" alt="Screenshot 2023-02-28 at 13 01 03" src="https://user-images.githubusercontent.com/9120292/221861310-02c550a2-1a3d-4466-93b1-9112693ce2ba.png">