### PR TITLE
feat(ios): Add feature to convert videos to MP4

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,21 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Options
 
-| Option         | iOS | Android | Web | Description                                                                                                                         |
-| -------------- | --- | ------- | --- |------------------------------------------------------------------------------------------------------------------------------------ |
-| mediaType      | OK  | OK      | OK  | 'photo' or 'video' or 'mixed'(launchCamera on Android does not support 'mixed'). Web only supports 'photo' for now.                             |
-| maxWidth       | OK  | OK      | NO | To resize the image                                                                                                                       |
-| maxHeight      | OK  | OK      | NO | To resize the image                                                                                                                       |
-| videoQuality   | OK  | OK      | NO | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                             |
-| durationLimit  | OK  | OK      | NO | Video max duration in seconds                                                                                                             |
-| quality        | OK  | OK      | NO | 0 to 1, photos                                                                                                                            |
-| cameraType     | OK  | OK      | NO | 'back' or 'front'. May not be supported in few android devices                                                                            |
-| includeBase64  | OK  | OK      | OK | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                         |                                                   |
-| includeExtra   | OK  | OK      | NO | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                      |
-| saveToPhotos   | OK  | OK      | NO |(Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
-| selectionLimit | OK  | OK      | OK |Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 & Android version >= 13 support `0` and also it supports providing any integer value |
-| presentationStyle | OK  | NO      | NO |Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
-| formatAsMp4| OK | NO | NO | Converts the selected video to MP4. iOS Only. |
-
+| Option            | iOS | Android | Web | Description                                                                                                                                                               |
+| ----------------- | --- | ------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| mediaType         | OK  | OK      | OK  | 'photo' or 'video' or 'mixed'(launchCamera on Android does not support 'mixed'). Web only supports 'photo' for now.                                                       |
+| maxWidth          | OK  | OK      | NO  | To resize the image                                                                                                                                                       |
+| maxHeight         | OK  | OK      | NO  | To resize the image                                                                                                                                                       |
+| videoQuality      | OK  | OK      | NO  | 'low', 'medium', or 'high' on iOS, 'low' or 'high' on Android                                                                                                             |
+| durationLimit     | OK  | OK      | NO  | Video max duration in seconds                                                                                                                                             |
+| quality           | OK  | OK      | NO  | 0 to 1, photos                                                                                                                                                            |
+| cameraType        | OK  | OK      | NO  | 'back' or 'front'. May not be supported in few android devices                                                                                                            |
+| includeBase64     | OK  | OK      | OK  | If true, creates base64 string of the image (Avoid using on large image files due to performance)                                                                         |     |
+| includeExtra      | OK  | OK      | NO  | If true, will include extra data which requires library permissions to be requested (i.e. exif data)                                                                      |
+| saveToPhotos      | OK  | OK      | NO  | (Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                                                      |
+| selectionLimit    | OK  | OK      | OK  | Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 & Android version >= 13 support `0` and also it supports providing any integer value         |
+| presentationStyle | OK  | NO      | NO  | Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
+| formatAsMp4       | OK  | NO      | NO  | Converts the selected video to MP4. iOS Only.                                                                                                                             |
 
 ## The Response Object
 
@@ -118,19 +117,19 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Asset Object
 
-| key       | iOS | Android | Web | Photo/Video | Requires Permissions | Description               |
-| --------- | --- | ------- | --- | ----------- | -------------------- | ------------------------- |
-| base64    | OK  | OK      | OK  | PHOTO ONLY  | NO                   | The base64 string of the image (photos only) |
+| key       | iOS | Android | Web | Photo/Video | Requires Permissions | Description                                                                                                                                                                                                                                                                    |
+| --------- | --- | ------- | --- | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| base64    | OK  | OK      | OK  | PHOTO ONLY  | NO                   | The base64 string of the image (photos only)                                                                                                                                                                                                                                   |
 | uri       | OK  | OK      | OK  | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library. For web it uses the base64 as uri. |
-| width     | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                |
-| height    | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                |
-| fileSize  | OK  | OK      | NO  | BOTH        | NO                   | The file size                                 |
-| type      | OK  | OK      | NO  | BOTH        | NO                   | The file type                                 |
-| fileName  | OK  | OK      | NO  | BOTH        | NO                   | The file name                                 |
-| duration  | OK  | OK      | NO  | VIDEO ONLY  | NO                   | The selected video duration in seconds        |
-| bitrate   | --- | OK      | NO  | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only) |
-| timestamp | OK  | OK      | NO  | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true |
-| id        | OK  | OK      | NO  | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName |
+| width     | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
+| height    | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
+| fileSize  | OK  | OK      | NO  | BOTH        | NO                   | The file size                                                                                                                                                                                                                                                                  |
+| type      | OK  | OK      | NO  | BOTH        | NO                   | The file type                                                                                                                                                                                                                                                                  |
+| fileName  | OK  | OK      | NO  | BOTH        | NO                   | The file name                                                                                                                                                                                                                                                                  |
+| duration  | OK  | OK      | NO  | VIDEO ONLY  | NO                   | The selected video duration in seconds                                                                                                                                                                                                                                         |
+| bitrate   | --- | OK      | NO  | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only)                                                                                                                                                                                          |
+| timestamp | OK  | OK      | NO  | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true                                                                                                                                                                                                                |
+| id        | OK  | OK      | NO  | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName                                                                                                                                                                                               |
 
 ## Note on file storage
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | saveToPhotos   | OK  | OK      | NO |(Boolean) Only for launchCamera, saves the image/video file captured to public photo                                                      |
 | selectionLimit | OK  | OK      | OK |Default is `1`, use `0` to allow any number of files. Only iOS version >= 14 & Android version >= 13 support `0` and also it supports providing any integer value |
 | presentationStyle | OK  | NO      | NO |Controls how the picker is presented. 'pageSheet', 'fullScreen', 'pageSheet', 'formSheet', 'popover', 'overFullScreen', 'overCurrentContext'. Default is 'currentContext' |
+| formatAsMp4| OK | NO | NO | Converts the selected video to MP4. iOS Only. |
+
 
 ## The Response Object
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -329,7 +329,7 @@ PODS:
   - React-jsinspector (0.71.2)
   - React-logger (0.71.2):
     - glog
-  - react-native-image-picker (5.0.2):
+  - react-native-image-picker (5.2.0):
     - React-Core
   - React-perflogger (0.71.2)
   - React-RCTActionSheet (0.71.2):
@@ -573,9 +573,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: d58428b28fe1f5070fe993495b0e2eaf701d3820
   FBReactNativeSpec: 225fb0f0ab00493ce0731f954da3658638d9b191
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -588,7 +588,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   hermes-engine: 6351580c827b3b03e5f25aadcf989f582d0b0a86
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7e028406112db456ac3cf5720d266bc7bc20938
   React-jsinspector: ea8101acf525ec08b2d87ddf0637d45f8e3b4148
   React-logger: 97987f46779d8dd24656474ad0c43a5b459f31d6
-  react-native-image-picker: 37fb87cdf0521003a6dabb877ad6ecd08c4f83ae
+  react-native-image-picker: d60541a8ad96ff1a2396457b6ff119aeaf17d0c8
   React-perflogger: c7ccda3d1d1da837f7ff4e54e816022a6803ee87
   React-RCTActionSheet: 01c125aebbad462a24228f68c584c7a921d6c28e
   React-RCTAnimation: 5277a9440acffc4a5b7baa6ae3880fe467277ae6
@@ -626,4 +626,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: ef73cbde42986f3fa5d93469f9a6bd4a5b4296c8
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
-  StyleSheet,
-  SafeAreaView,
-  View,
   Image,
-  ScrollView,
   Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  View,
 } from 'react-native';
-import {DemoTitle, DemoButton, DemoResponse} from './components';
+import {DemoButton, DemoResponse, DemoTitle} from './components';
 
 import * as ImagePicker from 'react-native-image-picker';
 
@@ -120,6 +120,7 @@ const actions: Action[] = [
     options: {
       selectionLimit: 0,
       mediaType: 'video',
+      formatAsMp4: true,
       includeExtra,
     },
   },

--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -270,7 +270,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         
         [[NSFileManager defaultManager] removeItemAtURL:outputURL error:nil];
         AVURLAsset *asset = [AVURLAsset URLAssetWithURL:videoDestinationURL options:nil];
-        AVAssetExportSession *exportSession = [[AVAssetExportSession alloc] initWithAsset:asset presetName:AVAssetExportPresetMediumQuality];
+        AVAssetExportSession *exportSession = [[AVAssetExportSession alloc] initWithAsset:asset presetName:AVAssetExportPresetHighestQuality];
         
         exportSession.outputURL = outputURL;
         exportSession.outputFileType = AVFileTypeMPEG4;
@@ -288,6 +288,8 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
                     response[@"fileSize"] = [ImagePickerUtils getFileSizeFromUrl:outputURL];
                     response[@"width"] = @(dimentions.width);
                     response[@"height"] = @(dimentions.height);
+                    dispatch_semaphore_signal(sem);
+                } else if (exportSession.status == AVAssetExportSessionStatusFailed || exportSession.status == AVAssetExportSessionStatusCancelled) {
                     dispatch_semaphore_signal(sem);
                 }
             }];

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface OptionsCommon {
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
   includeExtra?: boolean;
+  formatAsMp4?: boolean;
   presentationStyle?:
     | 'currentContext'
     | 'fullScreen'


### PR DESCRIPTION
This allows videos to be converted to MP4 on iOS.  For now the quality is lowered, to make it faster.

Non-MP4 video (no conversion)
![image](https://user-images.githubusercontent.com/1611055/224762684-5a99b66b-2406-43b1-8deb-5cff84aa2c61.png)

MP4 video (same video as above, with conversion)
![image](https://user-images.githubusercontent.com/1611055/224762764-d6a8a540-24cb-4908-8e83-4767f60cc2f8.png)
