### PR TITLE
fix(mp4): no longer hang on export when taking a video

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -110,6 +110,7 @@ const actions: Action[] = [
     type: 'capture',
     options: {
       saveToPhotos: true,
+      formatAsMp4: true,
       mediaType: 'video',
       includeExtra,
     },


### PR DESCRIPTION
This fixes a hang that occured on mp4 conversion when capturing a new video.
Also fixes the filename.