### PR TITLE
feat(web): enabling select video for web

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {
-  Image,
   Platform,
   SafeAreaView,
   ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
-import {DemoButton, DemoResponse, DemoTitle} from './components';
+import {Asset, DemoButton, DemoResponse, DemoTitle} from './components';
 
 import * as ImagePicker from 'react-native-image-picker';
 
@@ -15,15 +14,19 @@ import * as ImagePicker from 'react-native-image-picker';
 const includeExtra = true;
 
 export default function App() {
-  const [response, setResponse] = React.useState<any>(null);
+  const [response, setResponse] =
+    React.useState<ImagePicker.ImagePickerResponse | null>(null);
 
-  const onButtonPress = React.useCallback((type, options) => {
-    if (type === 'capture') {
-      ImagePicker.launchCamera(options, setResponse);
-    } else {
-      ImagePicker.launchImageLibrary(options, setResponse);
-    }
-  }, []);
+  const onButtonPress = React.useCallback(
+    (type: Action['type'], options: Action['options']) => {
+      if (type === 'capture') {
+        ImagePicker.launchCamera(options, setResponse);
+      } else {
+        ImagePicker.launchImageLibrary(options, setResponse);
+      }
+    },
+    [],
+  );
 
   return (
     <SafeAreaView style={styles.container}>
@@ -43,15 +46,8 @@ export default function App() {
         <DemoResponse>{response}</DemoResponse>
 
         {response?.assets &&
-          response?.assets.map(({uri}: {uri: string}) => (
-            <View key={uri} style={styles.imageContainer}>
-              <Image
-                resizeMode="cover"
-                resizeMethod="scale"
-                style={styles.image}
-                source={{uri: uri}}
-              />
-            </View>
+          response?.assets.map(asset => (
+            <Asset asset={asset} key={asset.uri} />
           ))}
       </ScrollView>
     </SafeAreaView>

--- a/example/src/components/Asset.tsx
+++ b/example/src/components/Asset.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import {Image, View, StyleSheet} from 'react-native';
+import type {Asset} from 'react-native-image-picker';
+import {isWebVideo} from '../utils/video';
+
+interface Props {
+  asset: Asset;
+}
+
+export function Asset({asset}: Props) {
+  if (isWebVideo(asset)) {
+    return (
+      <View style={styles.assetContainer}>
+        <video src={asset.uri} style={webVideoStyle} controls />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.assetContainer}>
+      <Image
+        resizeMode="cover"
+        resizeMethod="scale"
+        style={styles.asset}
+        source={{uri: asset.uri}}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  assetContainer: {
+    marginVertical: 24,
+    alignItems: 'center',
+  },
+  asset: {
+    width: 200,
+    height: 200,
+  },
+});
+
+const webVideoStyle = {
+  maxHeight: 200,
+};

--- a/example/src/components/DemoResponse.tsx
+++ b/example/src/components/DemoResponse.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import {Text, StyleSheet, ViewStyle, TextStyle, ScrollView} from 'react-native';
+import type {ImagePickerResponse} from 'react-native-image-picker';
 
-export function DemoResponse({children}: React.PropsWithChildren<{}>) {
+interface Props {
+  children: ImagePickerResponse | null;
+}
+
+export function DemoResponse({children}: Props) {
   if (children == null) {
     return null;
   }

--- a/example/src/components/index.ts
+++ b/example/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Asset';
 export * from './DemoButton';
 export * from './DemoTitle';
 export * from './DemoResponse';

--- a/example/src/utils/video.ts
+++ b/example/src/utils/video.ts
@@ -1,0 +1,6 @@
+import {Platform} from 'react-native';
+import type {Asset} from 'react-native-image-picker';
+
+export function isWebVideo(asset: Asset) {
+  return Platform.OS === 'web' && asset.uri?.startsWith('data:video/');
+}

--- a/src/platforms/web.ts
+++ b/src/platforms/web.ts
@@ -37,18 +37,6 @@ export function imageLibrary(
   options: ImageLibraryOptions = DEFAULT_OPTIONS,
   callback?: Callback,
 ): Promise<ImagePickerResponse> {
-  // Only supporting 'photo' mediaType for now.
-  if (options.mediaType !== 'photo') {
-    const result = {
-      errorCode: 'others' as ErrorCode,
-      errorMessage: 'For now, only photo mediaType is supported for web',
-    };
-
-    if (callback) callback(result);
-
-    return Promise.resolve(result);
-  }
-
   const input = document.createElement('input');
   input.style.display = 'none';
   input.setAttribute('type', 'file');


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation

Following up with #2014 for the web support for the library.

The video selection can also be enabled. Nothing was needed to make it work, just allow it and update the example app to be able to render videos.

- Works for mixed media types.
- And single media type selection.

## Test Plan

The example app has been updated. Video below


https://user-images.githubusercontent.com/20783123/230955889-a855cffa-0dda-4c56-8916-d71549c3a4d8.mov

