### PR TITLE
Add fallback to getting extension from filename

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -8,6 +8,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.camera2.CameraCharacteristics;
@@ -15,6 +16,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
+import android.provider.OpenableColumns;
 import android.util.Base64;
 import android.webkit.MimeTypeMap;
 
@@ -118,6 +120,21 @@ public class Utils {
         }
         ContentResolver contentResolver = context.getContentResolver();
         String fileType = getFileTypeFromMime(contentResolver.getType(sharedStorageUri));
+
+        if (fileType == null) {
+            Cursor cursor =
+                    contentResolver.query(sharedStorageUri, null, null, null, null);
+            if (cursor.moveToFirst()) {
+                int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                String fileName = cursor.getString(nameIndex);
+                int lastDotIndex = fileName.lastIndexOf('.');
+
+                if (lastDotIndex != -1) {
+                    fileType = fileName.substring(lastDotIndex + 1);
+                }
+            }
+        }
+
         Uri toUri =  Uri.fromFile(createFile(context, fileType));
         copyUri(sharedStorageUri, toUri, contentResolver);
         return toUri;


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

In some cases the [`getExtensionFromMimeType`](https://android.googlesource.com/platform/frameworks/base/+/0ea8c8a7c060873ef94e8aa8a637bc90852777d1/core/java/android/webkit/MimeTypeMap.java#151) may return `null`, in which case the generated file would lack the extension. This PR adds fallback to rely on the extension when it happens.

## Test Plan (required)

I wasn't able to make a reproducible example to showcase the problem, however, it emerged during the migration of the Expensify app to the new architecture. [We've been using the patch](https://github.com/Expensify/App/blob/a9c5bcbf52ee7c368c5390d58ea489d6b4f53d6e/patches/react-native-image-picker%2B5.3.1.patch#L25-L39) for a while and didn't see any problems with it.
