### PR TITLE
Fix android leaks

### DIFF
--- a/android/src/main/java/com/imagepicker/ImageMetadata.java
+++ b/android/src/main/java/com/imagepicker/ImageMetadata.java
@@ -8,8 +8,7 @@ import java.io.InputStream;
 
 public class ImageMetadata extends Metadata {
   public ImageMetadata(Uri uri, Context context) {
-    try {
-      InputStream inputStream = context.getContentResolver().openInputStream(uri);
+    try(InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
       ExifInterface exif = new ExifInterface(inputStream);
       String datetimeTag = exif.getAttribute(ExifInterface.TAG_DATETIME);
 
@@ -23,7 +22,7 @@ public class ImageMetadata extends Metadata {
 
   @Override
   public String getDateTime() { return datetime; }
-  
+
   // At the moment we are not using the ImageMetadata class to get width/height
   // TODO: to use this class for extracting image width and height in the future
   @Override

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -9,12 +9,26 @@ import android.util.Log;
 
 import java.io.IOException;
 
+// MetadataRetriever only implements AutoCloseable starting with Android API 29
+// So let's use our own wrapper for it
+// See https://stackoverflow.com/a/74808462/1377358
+class CustomMediaMetadataRetriever extends MediaMetadataRetriever implements AutoCloseable {
+   public CustomMediaMetadataRetriever() {
+      super();
+   }
+
+   @Override
+   public void close() throws IOException {
+      release();
+   }
+}
+
 public class VideoMetadata extends Metadata {
   private int duration;
   private int bitrate;
 
   public VideoMetadata(Uri uri, Context context) {
-    try(MediaMetadataRetriever metadataRetriever = new MediaMetadataRetriever()) {
+    try(CustomMediaMetadataRetriever metadataRetriever = new CustomMediaMetadataRetriever()) {
       metadataRetriever.setDataSource(context, uri);
 
       String duration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
@@ -47,8 +61,6 @@ public class VideoMetadata extends Metadata {
           this.height = Integer.parseInt(height);
         }
       }
-
-      metadataRetriever.release();
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -14,44 +14,43 @@ public class VideoMetadata extends Metadata {
   private int bitrate;
 
   public VideoMetadata(Uri uri, Context context) {
-    MediaMetadataRetriever metadataRetriever = new MediaMetadataRetriever();
-    metadataRetriever.setDataSource(context, uri);
+    try(MediaMetadataRetriever metadataRetriever = new MediaMetadataRetriever()) {
+      metadataRetriever.setDataSource(context, uri);
 
-    String duration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
-    String bitrate = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
-    String datetime = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE);
+      String duration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+      String bitrate = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
+      String datetime = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE);
 
-    // Extract anymore metadata here...
-    if(duration != null) this.duration = Math.round(Float.parseFloat(duration)) / 1000;
-    if(bitrate != null) this.bitrate = parseInt(bitrate);
+      // Extract anymore metadata here...
+      if(duration != null) this.duration = Math.round(Float.parseFloat(duration)) / 1000;
+      if(bitrate != null) this.bitrate = parseInt(bitrate);
 
-    if(datetime != null) {
-      // METADATA_KEY_DATE gives us the following format: "20211214T102646.000Z"
-      // This format is very hard to parse, so we convert it to "20211214 102646" ("yyyyMMdd HHmmss")
-      String datetimeToFormat = datetime.substring(0, datetime.indexOf(".")).replace("T", " ");
-      this.datetime = getDateTimeInUTC(datetimeToFormat, "yyyyMMdd HHmmss");
-    }
-
-    String width = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH);
-    String height = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT);
-
-    if(height != null && width != null) {
-      String rotation = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION);
-      int rotationI = rotation == null ? 0 : Integer.parseInt(rotation);
-
-      if(rotationI == 90 || rotationI == 270) {
-        this.width = Integer.parseInt(height);
-        this.height = Integer.parseInt(width);
-      } else {
-        this.width = Integer.parseInt(width);
-        this.height = Integer.parseInt(height);
+      if(datetime != null) {
+        // METADATA_KEY_DATE gives us the following format: "20211214T102646.000Z"
+        // This format is very hard to parse, so we convert it to "20211214 102646" ("yyyyMMdd HHmmss")
+        String datetimeToFormat = datetime.substring(0, datetime.indexOf(".")).replace("T", " ");
+        this.datetime = getDateTimeInUTC(datetimeToFormat, "yyyyMMdd HHmmss");
       }
-    }
 
-    try {
+      String width = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH);
+      String height = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT);
+
+      if(height != null && width != null) {
+        String rotation = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION);
+        int rotationI = rotation == null ? 0 : Integer.parseInt(rotation);
+
+        if(rotationI == 90 || rotationI == 270) {
+          this.width = Integer.parseInt(height);
+          this.height = Integer.parseInt(width);
+        } else {
+          this.width = Integer.parseInt(width);
+          this.height = Integer.parseInt(height);
+        }
+      }
+
       metadataRetriever.release();
     } catch (IOException e) {
-      Log.e("VideoMetadata", "IO error releasing metadataRetriever", e);
+      e.printStackTrace();
     }
   }
 


### PR DESCRIPTION
## Motivation (required)

While working on solving #2138, @huextrat noticed that the various streams and descriptors were never closed.

This is leaking a lot of resources.

I converted those to try-with-resources syntax, so they are automatically closed after the block ends.

## Test Plan (required)

I tested various files and videos with the example app, and did not notice any issue.

I also enabled `StrictMode` on the example app (see https://wh0.github.io/2020/08/12/closeguard.html) and it no longer detects non-closed resources.
