### PR TITLE
Process the files in a separate thread on Android

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
@@ -18,6 +18,8 @@ import com.facebook.react.module.annotations.ReactModule;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.imagepicker.Utils.*;
 
@@ -164,13 +166,17 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
     }
 
     void onAssetsObtained(List<Uri> fileUris) {
-        try {
-            callback.invoke(getResponseMap(fileUris, options, reactContext));
-        } catch (RuntimeException exception) {
-            callback.invoke(getErrorMap(errOthers, exception.getMessage()));
-        } finally {
-            callback = null;
-        }
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        executor.submit(() -> {
+            try {
+                callback.invoke(getResponseMap(fileUris, options, reactContext));
+            } catch (RuntimeException exception) {
+                callback.invoke(getErrorMap(errOthers, exception.getMessage()));
+            } finally {
+                callback = null;
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
## Motivation (required)

At the moment, when picking files on Android, all the processing (copying the file into the app's cache & extracting metadata) is made in the main thread.

This causes the app UI to become unavailable, and may trigger Android's Application Not Responding alerts, or have the application killed.

This changes runs the processing in a separate thread, that notifies the RN bridge once finished.

Ideally we could have a thread pool and have each file processed independently inside a thread, but I am not familiar enough with Java to do this properly.

## Test Plan (required)

I tested this both in Emulator and on a physical Android 13 phone, using the example app.

It worked fine with many videos or photos and the app UI was responsive.

I am trying to resurrect an older Android device to run the tests on it. 