### PR TITLE
feat(android): permit to specify a list of allowed mime-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ npx pod-install ios
 
 Add the appropriate keys to your `Info.plist` depending on your requirement:
 
-| Requirement                    | Key                                                 |
-| ------------------------------ | --------------------------------------------------- |
-| Select image/video from photos | NSPhotoLibraryUsageDescription                      |
-| Capture Image                  | NSCameraUsageDescription                            |
+| Requirement                    | Key                                                     |
+| ------------------------------ | ------------------------------------------------------- |
+| Select image/video from photos | NSPhotoLibraryUsageDescription                          |
+| Capture Image                  | NSCameraUsageDescription                                |
 | Capture Video                  | NSCameraUsageDescription & NSMicrophoneUsageDescription |
 
 ### Android
@@ -107,8 +107,9 @@ The `callback` will be called with a response object, refer to [The Response Obj
 ## Options
 
 | Option                  | iOS | Android | Web | Description                                                                                                                                                                                                                                |
-| ----------------------- | --- | ------- | --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------- | --- | ------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | mediaType               | OK  | OK      | OK  | `photo` or `video` or `mixed`(`launchCamera` on Android does not support 'mixed'). Web only supports 'photo' for now.                                                                                                                      |
+| restrictMimeTypes       | NO  | OK      | NO  | Array containing the mime-types allowed to be picked. Default is empty (everything).                                                                                                                                                       |
 | maxWidth                | OK  | OK      | NO  | To resize the image.                                                                                                                                                                                                                       |
 | maxHeight               | OK  | OK      | NO  | To resize the image.                                                                                                                                                                                                                       |
 | videoQuality            | OK  | OK      | NO  | `low`, `medium`, or `high` on iOS, `low` or `high` on Android.                                                                                                                                                                             |
@@ -124,6 +125,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | formatAsMp4             | OK  | NO      | NO  | Converts the selected video to MP4 (iOS Only).                                                                                                                                                                                             |
 | assetRepresentationMode | OK  | OK      | NO  | A mode that determines which representation to use if an asset contains more than one on iOS or disables HEIC/HEIF to JPEG conversion on Android if set to 'current'. Possible values: 'auto', 'current', 'compatible'. Default is 'auto'. |
 
+|
 
 ## The Response Object
 
@@ -136,20 +138,20 @@ The `callback` will be called with a response object, refer to [The Response Obj
 
 ## Asset Object
 
-| key       | iOS | Android | Web | Photo/Video | Requires Permissions | Description                                                                                                                                                                                                                                                                    |
-| --------- | --- | ------- | --- | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| base64    | OK  | OK      | OK  | PHOTO ONLY  | NO                   | The base64 string of the image (photos only)                                                                                                                                                                                                                                   |
-| uri       | OK  | OK      | OK  | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library. For web it uses the base64 as uri. |
-| originalPath       | NO  | OK      | NO  | BOTH        | NO                   | The original file path. |
-| width     | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
-| height    | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
-| fileSize  | OK  | OK      | NO  | BOTH        | NO                   | The file size                                                                                                                                                                                                                                                                  |
-| type      | OK  | OK      | NO  | BOTH        | NO                   | The file type                                                                                                                                                                                                                                                                  |
-| fileName  | OK  | OK      | NO  | BOTH        | NO                   | The file name                                                                                                                                                                                                                                                                  |
-| duration  | OK  | OK      | NO  | VIDEO ONLY  | NO                   | The selected video duration in seconds                                                                                                                                                                                                                                         |
-| bitrate   | --- | OK      | NO  | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only)                                                                                                                                                                                          |
-| timestamp | OK  | OK      | NO  | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true                                                                                                                                                                                                                |
-| id        | OK  | OK      | NO  | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName                                                                                                                                                                                               |
+| key          | iOS | Android | Web | Photo/Video | Requires Permissions | Description                                                                                                                                                                                                                                                                    |
+| ------------ | --- | ------- | --- | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| base64       | OK  | OK      | OK  | PHOTO ONLY  | NO                   | The base64 string of the image (photos only)                                                                                                                                                                                                                                   |
+| uri          | OK  | OK      | OK  | BOTH        | NO                   | The file uri in app specific cache storage. Except when picking **video from Android gallery** where you will get read only content uri, to get file uri in this case copy the file to app specific storage using any react-native library. For web it uses the base64 as uri. |
+| originalPath | NO  | OK      | NO  | BOTH        | NO                   | The original file path.                                                                                                                                                                                                                                                        |
+| width        | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
+| height       | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
+| fileSize     | OK  | OK      | NO  | BOTH        | NO                   | The file size                                                                                                                                                                                                                                                                  |
+| type         | OK  | OK      | NO  | BOTH        | NO                   | The file type                                                                                                                                                                                                                                                                  |
+| fileName     | OK  | OK      | NO  | BOTH        | NO                   | The file name                                                                                                                                                                                                                                                                  |
+| duration     | OK  | OK      | NO  | VIDEO ONLY  | NO                   | The selected video duration in seconds                                                                                                                                                                                                                                         |
+| bitrate      | --- | OK      | NO  | VIDEO ONLY  | NO                   | The average bitrate (in bits/sec) of the selected video, if available. (Android only)                                                                                                                                                                                          |
+| timestamp    | OK  | OK      | NO  | BOTH        | YES                  | Timestamp of the asset. Only included if 'includeExtra' is true                                                                                                                                                                                                                |
+| id           | OK  | OK      | NO  | BOTH        | YES                  | local identifier of the photo or video. On Android, this is the same as fileName                                                                                                                                                                                               |
 
 ## Note on file storage
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
@@ -157,6 +157,10 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
             libraryIntent = pickMultipleVisualMedia.createIntent(this.reactContext.getApplicationContext(), mediaRequest);
         }
 
+        if(this.options.restrictMimeTypes.length > 0) {
+            libraryIntent.putExtra(Intent.EXTRA_MIME_TYPES, this.options.restrictMimeTypes);
+        }
+
         try {
             currentActivity.startActivityForResult(libraryIntent, requestCode);
         } catch (ActivityNotFoundException e) {

--- a/android/src/main/java/com/imagepicker/Options.java
+++ b/android/src/main/java/com/imagepicker/Options.java
@@ -18,10 +18,13 @@ public class Options {
     int durationLimit;
     Boolean useFrontCamera = false;
     String mediaType;
-
+    String[] restrictMimeTypes;
 
     Options(ReadableMap options) {
         mediaType = options.getString("mediaType");
+        restrictMimeTypes = options.getArray("restrictMimeTypes").toArrayList().stream()
+                                .map(Object::toString)
+                                .toArray(size -> new String[size]);
         selectionLimit = options.getInt("selectionLimit");
         includeBase64 = options.getBoolean("includeBase64");
         includeExtra = options.getBoolean("includeExtra");

--- a/example/src/components/DemoResponse.tsx
+++ b/example/src/components/DemoResponse.tsx
@@ -7,7 +7,7 @@ export function DemoResponse({children}: React.PropsWithChildren<{}>) {
   }
 
   return (
-    <ScrollView style={styles.container}>
+    <ScrollView style={styles.container} nestedScrollEnabled>
       <Text style={styles.text}>{JSON.stringify(children, null, 2)}</Text>
     </ScrollView>
   );

--- a/src/platforms/native.ts
+++ b/src/platforms/native.ts
@@ -9,6 +9,7 @@ import {
 
 const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
   mediaType: 'photo',
+  restrictMimeTypes: [],
   videoQuality: 'high',
   quality: 1,
   maxWidth: 0,
@@ -26,9 +27,9 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
 // @ts-ignore We want to check whether __turboModuleProxy exitst, it may not
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
-const nativeImagePicker = isTurboModuleEnabled ?
-  require("./NativeImagePicker").default :
-  NativeModules.ImagePicker;
+const nativeImagePicker = isTurboModuleEnabled
+  ? require('./NativeImagePicker').default
+  : NativeModules.ImagePicker;
 
 export function camera(
   options: CameraOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,15 +16,13 @@ export interface OptionsCommon {
     | 'formSheet'
     | 'popover'
     | 'overFullScreen'
-    | 'overCurrentContext'
-    assetRepresentationMode?:
-    | 'auto'
-    | 'current'
-    | 'compatible';
+    | 'overCurrentContext';
+  assetRepresentationMode?: 'auto' | 'current' | 'compatible';
 }
 
 export interface ImageLibraryOptions extends OptionsCommon {
   selectionLimit?: number;
+  restrictMimeTypes?: string[];
 }
 
 export interface CameraOptions extends OptionsCommon {


### PR DESCRIPTION
## Motivation (required)

The Android camera app has an option to store both JPEG and RAW (DNG format) files for each picture. When this option is enabled, both versions of the image are shown to the user (but without any indication of the file format, so the users sees every image twice).

This new options allows you to restrict the allowed MIME types, for example `restrictMimeTypes: ['image/jpeg', 'image/heic', 'image/png']`.

On Android 13 (new Photo Picker), only the matching files are displayed, no more duplicates.

On older Android versions, every file is still displayed in the file explorer, but non-matching files are grayed and can not be selected.

This option can not be implemented on iOS, as the API only allows you to filter on predefined types (images, videos, slow-mos…).

## Test Plan (required)

I used `restrictMimeTypes: ['image/jpeg', 'image/heic', 'image/png']` with the example app and tested the behaviour with and without the option on an Android 10 and Android 13 devices.