### PR TITLE
fix(android): 🐛 only set namespace if gradle 7 or newer is used

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,8 +8,12 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
-    namespace = "com.imagepicker"
     compileSdkVersion 33
+
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.imagepicker"
+    }
 
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)


### PR DESCRIPTION
This removes the breaking change required to support the RN 0.73 and will support both older and newer versions.