### PR TITLE
fix: add support for iOS missing exif data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-picker",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
   "main": "src/index.ts",


### PR DESCRIPTION
Issue with photo export not adding existing `exif data` which vital aspect of an image.

What existing problem does the pull request solve?
Many issues [raise](https://github.com/react-native-image-picker/react-native-image-picker/issues?q=is%3Aissue+is%3Aopen+exif)
