### PR TITLE
fix(android): support rn version 0.68

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.imagepicker"
   >
     <application>
       <provider


### PR DESCRIPTION
## Motivation

v5.6.0 is no longer building for React-Native 0.68.

After upgrading react-native-image-picker from 5.4.2 to 5.5.0 my app no longer builds because of the following issue: `error: cannot find symbol new ImagePickerPackage()`

This issue was introduced here: 
https://github.com/react-native-image-picker/react-native-image-picker/commit/4584d7b0df4b859a73fc70aa2f17ba643885427f

This pr will fix these bugs :
- https://github.com/react-native-image-picker/react-native-image-picker/issues/1688
- https://github.com/react-native-image-picker/react-native-image-picker/issues/2154

## Test Plan

Build android

## My stack

Using react-native 0.68.2
Gradle 7.3.1
buildToolsVersion 33
compileSdkVersion 33
targetSdkVersion 33
minSdkVersion 24
kotlinVersion 1.7.0

## Temp workaround

Use `patch-package` with the following update

```
diff --git a/node_modules/react-native-image-picker/android/src/main/AndroidManifest.xml b/node_modules/react-native-image-picker/android/src/main/AndroidManifest.xml
index 2c5911e..2209799 100644
--- a/node_modules/react-native-image-picker/android/src/main/AndroidManifest.xml
+++ b/node_modules/react-native-image-picker/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.imagepicker"
   >
     <application>
       <provider
```