### PR TITLE
Ignore DateTime parsing errors

### DIFF
--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -40,10 +40,14 @@ public class VideoMetadata extends Metadata {
       if(bitrate != null) this.bitrate = parseInt(bitrate);
 
       if(datetime != null) {
-        // METADATA_KEY_DATE gives us the following format: "20211214T102646.000Z"
-        // This format is very hard to parse, so we convert it to "20211214 102646" ("yyyyMMdd HHmmss")
-        String datetimeToFormat = datetime.substring(0, datetime.indexOf(".")).replace("T", " ");
-        this.datetime = getDateTimeInUTC(datetimeToFormat, "yyyyMMdd HHmmss");
+        try{
+          // METADATA_KEY_DATE gives us the following format: "20211214T102646.000Z"
+          // This format is very hard to parse, so we convert it to "20211214 102646" ("yyyyMMdd HHmmss")
+          String datetimeToFormat = datetime.substring(0, datetime.indexOf(".")).replace("T", " ");
+          this.datetime = getDateTimeInUTC(datetimeToFormat, "yyyyMMdd HHmmss");
+        } catch (Exception e) {
+          Log.e("RNIP", "Invalid datetime format: " + e.getMessage());
+        }
       }
 
       String width = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH);


### PR DESCRIPTION
## Motivation (required)

There is a bug on Samsung SM-G935FD (Android 7) while taking a new video.
`launchCamera({mediaType: 'video'})` returns error `{"errorCode": "others", "errorMessage": "length=10; regionStart=0; regionLength=-1"}`.

Datetime metadata is "2023 09 05", that is unexpected format.

## Test Plan (required)


https://github.com/react-native-image-picker/react-native-image-picker/assets/35570211/7feecf4f-3ae9-4109-8f20-76c63f4e2f75


