### PR TITLE
Fix IOS video dimensions

### DIFF
--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -139,7 +139,15 @@
     
     if ([tracks count] > 0) {
         AVAssetTrack *track = [tracks objectAtIndex:0];
-        return track.naturalSize;
+         CGSize naturalSize = track.naturalSize;
+         CGAffineTransform preferredTransform = track.preferredTransform;
+         if (preferredTransform.a == 0 && preferredTransform.b == 1.0 && preferredTransform.c == -1.0 && preferredTransform.d == 0) {
+             // Video is in portrait mode
+             return CGSizeMake(naturalSize.height, naturalSize.width);
+         } else {
+             // Video is in landscape mode
+             return naturalSize;
+         }
     }
     
     return CGSizeMake(0, 0);


### PR DESCRIPTION
I found this solution on one of this package's issues and it worked perfectly with me, so instead of just patching it this can be a fix for everyone.

## Motivation (required)

When picking a MOV video from the camera picker or photos library, the picked dimensions are always in landscape mode even if you picked a portrait video, this PR fixes this behavior and returns the correct dimensions based on the correct mode.

## Test Plan (required)

Just try to record a video using the library in portrait mode and read the dimensions. 
1- Before this PR: 1920w * 1080h.
2- After this PR: 1080w * 1920h.  


