### PR TITLE
docs(readme): Modify video permission key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add the appropriate keys to your `Info.plist` depending on your requirement:
 | ------------------------------ | --------------------------------------------------- |
 | Select image/video from photos | NSPhotoLibraryUsageDescription                      |
 | Capture Image                  | NSCameraUsageDescription                            |
-| Capture Video                  | NSCameraUsageDescription & NSCameraUsageDescription |
+| Capture Video                  | NSCameraUsageDescription & NSMicrophoneUsageDescription |
 
 ### Android
 


### PR DESCRIPTION
## Motivation

Corrected iOS video permission key names in the README.

Issue: 'NSCameraUsageDescription' is a duplicate.

Before: NSCameraUsageDescription & NSCameraUsageDescription
After : NSCameraUsageDescription & NSMicrophoneUsageDescription

## Test Plan

Since this is a modification to the README documentation, there are no tests.

Link to '[NSMicrophoneUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmicrophoneusagedescription)'