### PR TITLE
Update iOS image picker

### DIFF
--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -1,3 +1,4 @@
+#import "UniformTypeIdentifiers/UniformTypeIdentifiers.h"
 #import "ImagePickerManager.h"
 #import "ImagePickerUtils.h"
 #import <React/RCTConvert.h>
@@ -173,7 +174,45 @@ NSData* extractImageData(UIImage* image){
     float quality = [self.options[@"quality"] floatValue];
     if (![image isEqual:newImage] || (quality >= 0 && quality < 1)) {
         if ([fileType isEqualToString:@"jpg"]) {
+            // Get image source data before mutating it
+            CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)data, nil);
+            CGMutableImageMetadataRef metadata = nil;
+            // Attempt to extract the existing image metadata
+            if (imageSource != nil) {
+              metadata = CGImageMetadataCreateMutableCopy(CGImageSourceCopyMetadataAtIndex(imageSource, 0, nil));
+            }
+            
             data = UIImageJPEGRepresentation(newImage, quality);
+            
+            // Set the image source to be the newly resized image
+            imageSource = CGImageSourceCreateWithData((CFDataRef)data, nil);
+            if (imageSource != nil && metadata != nil) {
+                // If we have existing metadata, merge that into new imageSource
+                CFMutableDataRef newData = CFDataCreateMutable(nil, 0);
+                CGImageDestinationRef destination = CGImageDestinationCreateWithData(newData, kUTTypeJPEG, 1, nil);
+                CGImageDestinationCopyImageSource(
+                                                  destination,
+                                                  imageSource,
+                                                  (CFDictionaryRef)@{
+                                                      (__bridge  NSString*)kCGImageDestinationMetadata : (__bridge  NSDictionary*)metadata,
+                                                      (__bridge  NSString*)kCGImageDestinationMergeMetadata : @YES
+                                                  },
+                                                  nil);
+                // Set the underlying data to the data created by the CGImageDestination
+                // Use __bridge_transfer to transfer ownership and release newData
+                data = (__bridge_transfer NSData*)newData; 
+                
+                // Release the CGImageDestination
+                if (destination != nil) {
+                    CFRelease(destination);
+                }
+            }
+            
+            // Release the CGImageSource
+            if (imageSource != nil) {
+                CFRelease(imageSource);
+            }
+            
         } else if ([fileType isEqualToString:@"png"]) {
             data = UIImagePNGRepresentation(newImage);
         }
@@ -434,6 +473,10 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
     }
 }
 
++ (NSDictionary *)getMetadataFromInfo:(NSDictionary *)info {
+    return info[UIImagePickerControllerMediaMetadata];
+}
+
 @end
 
 @implementation ImagePickerManager (UIImagePickerControllerDelegate)
@@ -457,7 +500,11 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         if ([info[UIImagePickerControllerMediaType] isEqualToString:(NSString *) kUTTypeImage]) {
             UIImage *image = [ImagePickerManager getUIImageFromInfo:info];
             
-            [assets addObject:[self mapImageToAsset:image data:[NSData dataWithContentsOfURL:[ImagePickerManager getNSURLFromInfo:info]] phAsset:asset]];
+            [assets addObject: [self mapImageToAsset: image
+                                                data: [NSData dataWithContentsOfURL: [ImagePickerManager getNSURLFromInfo:info]]
+                                            phAsset: asset
+                                            metadata: [ImagePickerManager getMetadataFromInfo: info]]];
+            [ImagePickerManager getNSURLFromInfo:info]] phAsset:asset]];
         } else {
             NSError *error;
             NSDictionary *videoAsset = [self mapVideoToAsset:info[UIImagePickerControllerMediaURL] phAsset:asset error:&error];
@@ -538,23 +585,39 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         
         dispatch_group_enter(completionGroup);
 
-        if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
+        if ([provider canLoadObjectOfClass:[UIImage class]]){
             NSString *identifier = provider.registeredTypeIdentifiers.firstObject;
             // Matches both com.apple.live-photo-bundle and com.apple.private.live-photo-bundle
             if ([identifier containsString:@"live-photo-bundle"]) {
                 // Handle live photos
-                identifier = @"public.jpeg";
+                identifier = UTTypeImage.identifier;
             }
 
             [provider loadFileRepresentationForTypeIdentifier:identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
                 NSData *data = [[NSData alloc] initWithContentsOfURL:url];
                 UIImage *image = [[UIImage alloc] initWithData:data];
                 
-                assets[index] = [self mapImageToAsset:image data:data phAsset:asset];
+                assets[index] = [self mapImageToAsset:image data:data phAsset:asset metadata: nil];
                 dispatch_group_leave(completionGroup);
             }];
-        } else if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeMovie]) {
-            [provider loadFileRepresentationForTypeIdentifier:(NSString *)kUTTypeMovie completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
+        } else if ([provider hasItemConformingToTypeIdentifier: UTTypeHEIC.identifier]) {
+            // No jpeg is present, but a heic is -- this is still an image, so we'll convert it
+            [provider loadFileRepresentationForTypeIdentifier: UTTypeHEIC.identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                NSData *data = [[NSData alloc] initWithContentsOfURL:url];
+                UIImage *image = [[UIImage alloc] initWithData:data];
+                [assets addObject:[self mapImageToAsset:image data:data phAsset:asset metadata: nil]];
+                dispatch_group_leave(completionGroup);
+            }]; 
+        } else if ([provider hasItemConformingToTypeIdentifier: UTTypeHEIF.identifier]) {
+            // No jpeg is present, but a heif is -- this is still an image, so we'll convert it
+            [provider loadFileRepresentationForTypeIdentifier: UTTypeHEIF.identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                NSData *data = [[NSData alloc] initWithContentsOfURL:url];
+                UIImage *image = [[UIImage alloc] initWithData:data];
+                [assets addObject:[self mapImageToAsset:image data:data phAsset:asset metadata: nil]];
+                dispatch_group_leave(completionGroup);
+            }]; 
+        } else if ([provider hasItemConformingToTypeIdentifier: UTTypeMovie.identifier]) {
+            [provider loadFileRepresentationForTypeIdentifier: UTTypeMovie.identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
                 NSDictionary *mappedAsset = [self mapVideoToAsset:url phAsset:asset error:nil];
                 if (nil != mappedAsset) {
                     assets[index] = mappedAsset;


### PR DESCRIPTION
* Preserve metadata for images when targeting JPEG output
* Fixes #2220 - continue picker if only available format is HEIF or HEIC

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

This change has two motivations:

* preserve image metadata instead of tossing it away
* workaround what appears to be an API bug in iOS17 with `NSItemProvider#canLoadObjectOfClass` returning `false` for an item provider with only a `HEIF` or `HEIC` image.

## Test Plan (required)

For the iCloud but, this requires testing with two live devices to verify things work as expected.
1.  Take a photo on a device logged into an iCloud account.
2. Use this library on  a device on iOS 17 logged into the same iCloud account.
3. Select the image synced over with iCloud (without making any edits)
4. Without this change, see that the results array is empty. With this change, see that you have your image.

For the metadata:
1. Select any image. 
2. View the metadata of the image after selection before and after this change. Before, metadata like EXIF and GPS is missing. With this change, metadata is included. (both with camera or picker -- GPS would require a separate effort, but image EXIF data will be included.)