### PR TITLE
Update react-native-image-picker.podspec

### DIFF
--- a/react-native-image-picker.podspec
+++ b/react-native-image-picker.podspec
@@ -14,7 +14,10 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/react-native-image-picker/react-native-image-picker.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m,mm}"
-  s.pod_target_xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-fcxx-modules' }
+  s.pod_target_xcconfig = {
+  	'OTHER_CPLUSPLUSFLAGS' => '-fcxx-modules',
+ 	  'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => true
+  }
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
     folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'


### PR DESCRIPTION
See: https://github.com/react-native-image-picker/react-native-image-picker/pull/2229

Fixes RN when using `use_frameworks!` which is necessary when using things like Firebase