### PR TITLE
fix(#2119): make live photo identifier more generic

### DIFF
--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -1,3 +1,4 @@
+#import "UniformTypeIdentifiers/UniformTypeIdentifiers.h"
 #import "ImagePickerManager.h"
 #import "ImagePickerUtils.h"
 #import <React/RCTConvert.h>
@@ -543,7 +544,7 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
             // Matches both com.apple.live-photo-bundle and com.apple.private.live-photo-bundle
             if ([identifier containsString:@"live-photo-bundle"]) {
                 // Handle live photos
-                identifier = @"public.jpeg";
+                identifier = UTTypeImage.identifier;
             }
 
             [provider loadFileRepresentationForTypeIdentifier:identifier completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {


### PR DESCRIPTION
## Motivation

[Issue 2119](https://github.com/react-native-image-picker/react-native-image-picker/issues/2119)

We are running into the problem outlined in issue 2119 where there is a "Could not find image file..." error on iOS when selecting images that are on iCloud but not yet fully synced to the user's device.

I found by updating the live photo identifier to be more generic (rather than it explicitly being "public.jpeg") this resolved the issue.

_Please note: I am a React Native / Javascript developer, and not by any means a native iOS / Objective C developer. To reach the solution in this PR I referenced the code in [this PR](https://github.com/react-native-image-picker/react-native-image-picker/pull/2221), and added the least amount I could to resolve the issue. Someone with more native iOS experience may be able to suggest a more robust solution to the issue._

## Test Plan

(Requires testing with two devices logged into the same iCloud account)

- Take a photo on device A
- Use the example app on device B logged into the same iCloud account
- Select the image synced over with iCloud (without making any edits)
- Without this change you'll get the "Could not find image file..." warning. With this change, you'll retrieve the image as expected.
