### PR TITLE
fix: correct typo in variable name nativeImagePicler

### DIFF
--- a/src/platforms/native.ts
+++ b/src/platforms/native.ts
@@ -26,7 +26,7 @@ const DEFAULT_OPTIONS: ImageLibraryOptions & CameraOptions = {
 // @ts-ignore We want to check whether __turboModuleProxy exitst, it may not
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
-const nativeImagePicler = isTurboModuleEnabled ?
+const nativeImagePicker = isTurboModuleEnabled ?
   require("./NativeImagePicker").default :
   NativeModules.ImagePicker;
 
@@ -35,7 +35,7 @@ export function camera(
   callback?: Callback,
 ): Promise<ImagePickerResponse> {
   return new Promise((resolve) => {
-    nativeImagePicler.launchCamera(
+    nativeImagePicker.launchCamera(
       {...DEFAULT_OPTIONS, ...options},
       (result: ImagePickerResponse) => {
         if (callback) callback(result);
@@ -50,7 +50,7 @@ export function imageLibrary(
   callback?: Callback,
 ): Promise<ImagePickerResponse> {
   return new Promise((resolve) => {
-    nativeImagePicler.launchImageLibrary(
+    nativeImagePicker.launchImageLibrary(
       {...DEFAULT_OPTIONS, ...options},
       (result: ImagePickerResponse) => {
         if (callback) callback(result);


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

This pull request addresses the issue of a typographical error in our codebase. The incorrect variable name 'nativeImagePicler' has been corrected to 'nativeImagePicker'. This correction improves the readability and accuracy of the code, ensuring that our naming conventions are consistent and clear. It also prevents potential bugs and errors that might arise from using an incorrectly named variable in future developments. This small yet significant change contributes to the overall health and maintainability of the project.


## Test Plan (required)

No test is needed