### PR TITLE
Example with notifee foreground notification to keep the app alive in background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ example/ios-bundle.js
 index.android.bundle
 index.ios.bundle
 lib/
+.history/*

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,5 +14,4 @@
                 android:resource="@xml/imagepicker_provider_paths" />
         </provider>
     </application>
-    <uses-permission android:name="android.permission.CAMERA" />
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,4 +14,5 @@
                 android:resource="@xml/imagepicker_provider_paths" />
         </provider>
     </application>
+    <uses-permission android:name="android.permission.CAMERA" />
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Require for Android < 10 -->
+    <!-- <uses-permission android:name="android.permission.CAMERA" /> -->
 
     <application
       android:name=".MainApplication"

--- a/example/index.js
+++ b/example/index.js
@@ -5,5 +5,12 @@
 import {AppRegistry} from 'react-native';
 import App from './src/App';
 import {name as appName} from './app.json';
+import notifee from '@notifee/react-native';
+
+// To silent warn [notifee] no background event handler has been set. Set a handler via the "onBackgroundEvent" method.
+// Or handle the notification being cliked in the system tray
+notifee.onBackgroundEvent(async (detail) => {
+    console.log('Background event received: ', detail);    
+});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/example/package.json
+++ b/example/package.json
@@ -11,10 +11,12 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@notifee/react-native": "^7.8.0",
     "react": "18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "0.71.11",
     "react-native-image-picker": "link:../",
+    "react-native-permissions": "^3.10.1",
     "react-native-web": "0.17.7"
   },
   "devDependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,7 +10,7 @@ import {
 import {DemoButton, DemoResponse, DemoTitle} from './components';
 
 import * as ImagePicker from 'react-native-image-picker';
-import { PERMISSIONS, RESULTS, check, request } from 'react-native-permissions';
+import { PERMISSIONS, Permission, RESULTS, check, request } from 'react-native-permissions';
 import notifee, { AndroidColor, AndroidImportance } from '@notifee/react-native';
 
 /* toggle includeExtra */
@@ -175,11 +175,15 @@ if (Platform.OS === 'ios') {
 
 
 const requestCameraPermissionIfNeeded = async () => {
-  const result = await check(PERMISSIONS.ANDROID.CAMERA)
+  var permission: Permission = PERMISSIONS.IOS.CAMERA;
+  if (Platform.OS === 'android') {
+    permission = PERMISSIONS.ANDROID.CAMERA;
+  }
+  const result = await check(permission)
 
   if(result === RESULTS.GRANTED)  return true;
   else if (result === RESULTS.DENIED) {
-    const result = await request(PERMISSIONS.ANDROID.CAMERA)
+    const result = await request(permission)
     if(result === RESULTS.GRANTED)  return true;
   }
   return false;
@@ -187,7 +191,7 @@ const requestCameraPermissionIfNeeded = async () => {
 
 const registerForegroundNotification = async () => {
   if (Platform.OS === 'android') {
-    // Need permission since Android 14
+    // Need permission since Android 13
     const result = await notifee.requestPermission();
 
     const channelId = await notifee.createChannel({

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -22,12 +22,12 @@ export default function App() {
   const onButtonPress = React.useCallback(async (type , options) => {
     if (type === 'capture') {
       try {
-      await registerForegroundNotification();
-      const response = await ImagePicker.launchCamera(options);
-      setResponse(response);
-    } finally {
-      await stopForegroundNotification();
-    }
+        await registerForegroundNotification();
+        const response = await ImagePicker.launchCamera(options);
+        setResponse(response);
+      } finally {
+        await stopForegroundNotification();
+      }
     } else if (type === 'library') {
       ImagePicker.launchImageLibrary(options, setResponse);
     }
@@ -36,7 +36,6 @@ export default function App() {
         setResponse(result ? 'Permission Granted' : 'Permission Denied');
       })
     }
-    
   }, []);
 
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1121,6 +1121,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@notifee/react-native@^7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@notifee/react-native/-/react-native-7.8.0.tgz#2990883753990f3585aa0cb5becc5cbdbcd87a43"
+  integrity sha512-sx8h62U4FrR4pqlbN1rkgPsdamDt9Tad0zgfO6VtP6rNJq/78k8nxUnh0xIX3WPDcCV8KAzdYCE7+UNvhF1CpQ==
+
 "@react-native-community/cli-clean@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz#4c73ce93a63a24d70c0089d4025daac8184ff504"
@@ -6562,6 +6567,11 @@ react-native-gradle-plugin@^0.71.19:
 "react-native-image-picker@link:..":
   version "0.0.0"
   uid ""
+
+react-native-permissions@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.10.1.tgz#cb0171c8d12113869deaabbdfb979aad1a44752b"
+  integrity sha512-Gc5BxxpjZn4QNUDiVeHOO0vXh3AH7ToolmwTJozqC6DsxV7NAf3ttap+8BSmzDR8WxuAM3Cror+YNiBhHJx7/w==
 
 react-native-web@0.17.7:
   version "0.17.7"


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
I enhanced the example project to give a complete, working example of the Notifee foreground service, keeping the app alive in the background when taking a picture or video with the camera.

What existing problem does the pull request solve?
Solve the problem where the app is killed in the background while using the camera, and when exiting the camera, your app gets restarted and lands on the home page.

## Test Plan (required)

Using the simulator on different Android versions, I validated that we were seeing the foreground notification.
This is also where I found that Android 8 and 9 required camera permission, even if it was not in the manifest. , So I provide another example of requesting camera permission.

<img width="423" alt="Screenshot 2023-11-22 at 10 42 48 PM" src="https://github.com/react-native-image-picker/react-native-image-picker/assets/77302423/9477d4da-923f-405c-b6f8-feefc7b4a6f5">
<img width="435" alt="Screenshot 2023-11-22 at 10 42 56 PM" src="https://github.com/react-native-image-picker/react-native-image-picker/assets/77302423/551b3551-2c9a-40e2-910d-5ca5a5dca35c">
<img width="437" alt="Screenshot 2023-11-22 at 10 43 21 PM" src="https://github.com/react-native-image-picker/react-native-image-picker/assets/77302423/0d69714c-0641-49ee-b6e8-64d76265698d">
<img width="430" alt="Screenshot 2023-11-22 at 10 43 44 PM" src="https://github.com/react-native-image-picker/react-native-image-picker/assets/77302423/23943307-2b79-4b07-af53-779fc25a341f">

