### PR TITLE
Failed to build when `RCT_NEW_ARCH_ENABLED=1`

### DIFF
--- a/ios/ImagePickerManager.h
+++ b/ios/ImagePickerManager.h
@@ -29,7 +29,7 @@ RCT_ENUM_CONVERTER(
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import "RNImagePickerSpec.h"
-@interface ImagePickerManager : NSObject <RNImagePickerSpec>
+@interface ImagePickerManager : NSObject <NativeImagePickerSpec>
 @end
 
 #else


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

I use your package for the example of my react-native library in react-native 0.73.
When I build my example with the new architecture enable, I face the issue:
```
▸ Compiling ImagePickerManager.mm

❌  /Users/thibault/StudioProjects/api.video-reactnative-uploader/example/node_modules/react-native-image-picker/ios/ImagePickerManager.h:32:43: no type or protocol named 'RNImagePickerSpec'

@interface ImagePickerManager : NSObject <RNImagePickerSpec>
                                                    ^
```
Full logs is available here: https://github.com/apivideo/api.video-reactnative-uploader/actions/runs/7142227360/job/19451072582#logs

What existing problem does the pull request solve?

I think the reason it fails it is because the interface should implement `NativeImagePickerSpec` instead of `RNImagePickerSpec`.

See https://reactnative.dev/docs/0.72/the-new-architecture/pillars-turbomodules#rtncalculatorh

## Test Plan (required)

As I am not super familiar with RN, I could not find a way to build your library with `RCT_NEW_ARCH_ENABLED=1`.
Is there a way to build your library for iOS?

Anyway, I tested to locally change `ImagePickerManager.h` in my local project and it did fix the compilation issue.

You can check that my project is not building with the following commands:

```bash
git clone -b feature/new_arch_support git@github.com:apivideo/api.video-reactnative-uploader.git
cd api.video-reactnative-uploader
yarn && yarn example ios
```