### PR TITLE
fix: correctly handling 2 missing orientations on android (#2058)

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -199,7 +199,9 @@ public class Utils {
 
     private static boolean needToSwapDimension(String orientation){
         return orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_90))
-                || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_270));
+                || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_270))
+                || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_TRANSPOSE))
+                || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_TRANSVERSE));
     }
 
     // Resize image


### PR DESCRIPTION
ISSUE
------

On Android, the returned width and height are swapped for images containing EXIF orientation 5([ORIENTATION_TRANSPOSE](https://developer.android.com/reference/android/media/ExifInterface#ORIENTATION_TRANSPOSE)) and 7([ORIENTATION_TRANSVERSE](https://developer.android.com/reference/android/media/ExifInterface#ORIENTATION_TRANSVERSE)).

Can be verified with the following test images:
  - [Landscape_5.jpg](https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_5.jpg)
  - [Landscape_7.jpg](https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_7.jpg)

FIX
----
Android: Added checks for the 2 missing orientations before swapping dimensions.