### PR TITLE
Fix iOS build "ImagePickerManager.h:32:43: No type or protocol named 'RNImagePickerSpec'"

### DIFF
--- a/ios/ImagePickerManager.h
+++ b/ios/ImagePickerManager.h
@@ -29,7 +29,7 @@ RCT_ENUM_CONVERTER(
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import "RNImagePickerSpec.h"
-@interface ImagePickerManager : NSObject <RNImagePickerSpec>
+@interface ImagePickerManager : NSObject <NativeImagePickerSpec>
 @end
 
 #else


### PR DESCRIPTION


Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

I can't build RN app with NEW_ARCH enabled

## Test Plan (required)

```sh
npx react-native init Rn73
cd Rn73
yarn add react-native-image-picker
NO_FLIPPER=1 RCT_NEW_ARCH_ENABLED=1 npx pod-install
yarn ios
# ^^^ ImagePickerManager.h:32:43: No type or protocol named 'RNImagePickerSpec'
```
