### PR TITLE
FIX: iOS video dimensions

### DIFF
--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -139,7 +139,16 @@
     
     if ([tracks count] > 0) {
         AVAssetTrack *track = [tracks objectAtIndex:0];
-        return track.naturalSize;
+        CGSize naturalSize = track.naturalSize;
+        CGAffineTransform preferredTransform = track.preferredTransform;
+
+        if (preferredTransform.a == 0 && preferredTransform.b == 1.0 && preferredTransform.c == -1.0 && preferredTransform.d == 0) {
+            // Video is in portrait mode
+            return CGSizeMake(naturalSize.height, naturalSize.width);
+        } else {
+            // Video is in landscape mode
+            return naturalSize;
+        }
     }
     
     return CGSizeMake(0, 0);


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
faced an issue with video dimensions on iOS(iPhone 11 Pro Max).
```
launchCamera({
        mediaType: "video",
        presentationStyle: 'fullScreen',
})
```
1) call `launchCamera`
2) film generic protrait video
3) `launchCamera` returns:
```
{
    "assets": [
        {
            ...
            "type": "video/quicktime",
            "width": 1920,
            "height": 1080
        }
    ]
}
``` 
`width = 1920` and `height = 1080`
should be
`width = 1080` and `height = 1920`


## Test Plan (required)
Portrait mode
1) call `launchCamera`
2) film generic portrait video
3)  check `launchCamera` return to match `width` & `height` to have the correct aspect ratio

Horizontal mode
1) call `launchCamera`
2) film generic horizontal video
3)  check `launchCamera` return to match `width` & `height` to have correct aspect ratio

Relevant issue - https://github.com/react-native-image-picker/react-native-image-picker/issues/2038
Original solution author - https://github.com/react-native-image-picker/react-native-image-picker/issues/2038#issuecomment-1498729032