### PR TITLE
fix(ios): Fix support for new architecture on react-native 0.74

### DIFF
--- a/ios/ImagePickerUtils.mm
+++ b/ios/ImagePickerUtils.mm
@@ -22,7 +22,7 @@
     if (target == camera) {
         picker.sourceType = UIImagePickerControllerSourceTypeCamera;
 
-        if (options[@"durationLimit"] > 0) {
+        if ([options[@"durationLimit"] doubleValue] > 0) {
             picker.videoMaximumDuration = [options[@"durationLimit"] doubleValue];
         }
 

--- a/react-native-image-picker.podspec
+++ b/react-native-image-picker.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-image-picker/react-native-image-picker.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m,mm}"
 
-  s.frameworks             = "MobileCoreServices"
+  s.frameworks   = 'Photos','PhotosUI'
 
   if defined?(install_modules_dependencies) != nil
     install_modules_dependencies(s)


### PR DESCRIPTION
## Motivation (required)

When trying to build on iOS with new architecture enabled, user face the following error 
![image](https://github.com/react-native-image-picker/react-native-image-picker/assets/11707729/b6695f88-385d-4220-b94f-9db9e95fa473)

Given that we're importing `ImagePickerManager.h` inside `ios/ImagePickerUtils.mm`, which imports `RNImagePickerSpec.h`, we need to rename this file to `.mm`

After this change a different error shows up regarding `ld` not finding the following simbols:
```
ld: Undefined symbols:
  _OBJC_CLASS_$_PHAsset, referenced from:
       in libreact-native-image-picker.a[2](ImagePickerManager.o)
  _OBJC_CLASS_$_PHPhotoLibrary, referenced from:
       in libreact-native-image-picker.a[2](ImagePickerManager.o)
  _OBJC_CLASS_$_PHPickerConfiguration, referenced from:
       in libreact-native-image-picker.a[3](ImagePickerUtils.o)
  _OBJC_CLASS_$_PHPickerFilter, referenced from:
       in libreact-native-image-picker.a[3](ImagePickerUtils.o)
  _OBJC_CLASS_$_PHPickerViewController, referenced from:
       in libreact-native-image-picker.a[2](ImagePickerManager.o)
```

This can be fixed by specifying the `Photos` and `PhotosUI` frameworks inside the podspec file

## Test Plan (required)

Manually bump the example app to 0.73.0-rc3 (https://react-native-community.github.io/upgrade-helper/?from=0.73.6&to=0.74.0-rc.3), run `RCT_NEW_ARCH_ENABLED=1 pod install` and build the app
