### PR TITLE
fix: change minSdkVersion for RN 0.74.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)

React Native 0.74.1 added [the minimum SDK version bump to 23](https://reactnative.dev/blog/2024/04/22/release-0.74#android-minimum-sdk-bump-android-60). This PR tends to add the same, making sure the previous 21 is intact.

## Test Plan (required)

Run example app on android.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
