### PR TITLE
fix(web): Cancelling image picker does not resolve the promise

### DIFF
--- a/src/platforms/web.ts
+++ b/src/platforms/web.ts
@@ -61,7 +61,7 @@ export function imageLibrary(
   document.body.appendChild(input);
 
   return new Promise((resolve) => {
-    input.addEventListener('change', async () => {
+    const inputChangeHandler = async () => {
       if (input.files) {
         if (options.selectionLimit! <= 1) {
           const img = await readFile(input.files[0], {
@@ -90,8 +90,22 @@ export function imageLibrary(
           resolve(result);
         }
       }
+      cleanup();
+    };
+
+    const inputCancelHandler = async () => {
+      resolve({didCancel: true});
+      cleanup();
+    };
+
+    const cleanup = () => {
+      input.removeEventListener('change', inputChangeHandler);
+      input.removeEventListener('cancel', inputCancelHandler);
       document.body.removeChild(input);
-    });
+    };
+
+    input.addEventListener('change', inputChangeHandler);
+    input.addEventListener('cancel', inputCancelHandler);
 
     const event = new MouseEvent('click');
     input.dispatchEvent(event);


### PR DESCRIPTION
## Motivation (required)

The `cancel` input event is not handled, so if the user attempts to cancel the picking process, the promise that the library returns will never be resolved. Most likely this will result in app code that is stuck waiting for the user to make a selection.

## Test Plan (required)

- Invoke `launchImageLibrary` on web
- Cancel the file selection dialog that appears
- Notice that the promise from `launchImageLibrary` is not resolved, and never will be