### PR TITLE
fix(ios): missing required frameworks

### DIFF
--- a/react-native-image-picker.podspec
+++ b/react-native-image-picker.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-image-picker/react-native-image-picker.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m,mm}"
 
-  s.frameworks   = 'Photos','PhotosUI'
+  s.frameworks   = 'Photos','PhotosUI', 'AVFoundation', 'CoreMedia'
 
   if defined?(install_modules_dependencies) != nil
     install_modules_dependencies(s)


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
After installing version 7.1.2, when I run the iOS project it won't compile since it complains of undefined classes
It is related to this issue https://github.com/react-native-image-picker/react-native-image-picker/issues/2318

What existing problem does the pull request solve?
It compiles the iOS project in latest version

## Test Plan (required)
I don't know how you make it work in your environment but if these frameworks are missing it won't work

