### PR TITLE
Fixed duplicate cached files on android - gallery selection

### DIFF
--- a/android/src/main/java/com/imagepicker/Utils.java
+++ b/android/src/main/java/com/imagepicker/Utils.java
@@ -437,7 +437,6 @@ public class Utils {
         String originPath;
         if (uri.getScheme().contains("content")) {
             originPath = getFilePathFromContent(uri, context);
-            uri = getAppSpecificStorageUri(uri, context);
         } else {
             originPath = uri.toString();
         }


### PR DESCRIPTION
Fixed issue https://github.com/react-native-image-picker/react-native-image-picker/issues/2271

## Motivation

When picking images from the gallery on android - for each file 2 duplicate files are copied in the cache:
1. `onAssetsObtained` -> `getResponseMap` -> `getAppSpecificStorageUri` -> `createFile` -> `copyUri`
2. `onAssetsObtained` -> `getResponseMap` -> `getImageResponseMap` -> `getOriginalFilePath` -> `getAppSpecificStorageUri` -> `createFile` -> `copyUri`

So, as you can see, there are 2 calls to `getAppSpecificStorageUri`.

## Test Plan

Tested on `react-native-image-picker@7.0.0` - functions `launchCamera` (for bot `video` and `photo` mediaType) and `launchImageLibrary` are still working, making one copy in cache dir.

Now after picking images from the gallery - only one copy is being created in caches dir:

![image](https://github.com/user-attachments/assets/e2cf824f-1f64-498c-a0e4-735d00cec9b4)
