### PR TITLE
fix(android): video timestamps have the wrong timezone

### DIFF
--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -41,9 +41,9 @@ public class VideoMetadata extends Metadata {
 
             if (datetime != null) {
                 // METADATA_KEY_DATE gives us the following format: "20211214T102646.000Z"
-                // This format is very hard to parse, so we convert it to "20211214 102646" ("yyyyMMdd HHmmss")
-                String datetimeToFormat = datetime.substring(0, datetime.indexOf(".")).replace("T", " ");
-                this.datetime = getDateTimeInUTC(datetimeToFormat, "yyyyMMdd HHmmss");
+                // This date is always returned in UTC, so we strip the ending that `SimpleDateFormat` can't parse, and append `+GMT`
+                String datetimeToFormat = datetime.substring(0, datetime.indexOf(".")) + "+GMT";
+                this.datetime = getDateTimeInUTC(datetimeToFormat, "yyyyMMdd'T'HHmmss+zzz");
             }
 
             String width = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH);


### PR DESCRIPTION
## Motivation (required)

Timestamp for video files on Android were incorrect, offsetted by the user's device timezone.

The code previously dropped the timezone information (which was always GMT from my testing), but did not include it in the string date when parsing it, resulting in this GMT date being parsed with the current timezone.

With this fix, it is now correctly parsed as a GMT date.

I also updated the format to avoid having to replace the `T` as this can be processed correctly by the date parser.

## Test Plan (required)

This has been tested in the example app with multiple video files from real devices having date information using a timezone.

After those changes, the timestamps are correct.
