### PR TITLE
fix: video quality setting not working in mixed mode on iOS

### DIFF
--- a/ios/ImagePickerUtils.mm
+++ b/ios/ImagePickerUtils.mm
@@ -6,7 +6,7 @@
 
 + (void) setupPickerFromOptions:(UIImagePickerController *)picker options:(NSDictionary *)options target:(RNImagePickerTarget)target
 {
-    if ([[options objectForKey:@"mediaType"] isEqualToString:@"video"]) {
+    if ([options[@"mediaType"] isEqualToString:@"video"] || [options[@"mediaType"] isEqualToString:@"mixed"]) {
 
         if ([[options objectForKey:@"videoQuality"] isEqualToString:@"high"]) {
             picker.videoQuality = UIImagePickerControllerQualityTypeHigh;


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `main` branch, NOT a "stable" branch.

## Motivation (required)
Fix the video quality setting not working in mixed mode on iOS

What existing problem does the pull request solve?
Solve the following issues:
* #2256 
* #2161 
* #2123 
* #1908 

## Test Plan (required)
Tested changes on Simulator and real iPhone devices.

If you have added code that should be tested, add tests.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
