### PR TITLE
fix(ios): wait for view controller dismiss completion

### DIFF
--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -506,8 +506,6 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
 
 - (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results API_AVAILABLE(ios(14))
 {
-    [picker dismissViewControllerAnimated:YES completion:nil];
-
     if (photoSelected == YES) {
         return;
     }
@@ -515,7 +513,9 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
 
     if (results.count == 0) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.callback(@[@{@"didCancel": @YES}]);
+            [picker dismissViewControllerAnimated:YES completion:^{
+                self.callback(@[@{@"didCancel": @YES}]);
+            }];
         });
         return;
     }
@@ -571,7 +571,9 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         //  mapVideoToAsset can fail and return nil, leaving asset NSNull.
         for (NSDictionary *asset in assets) {
             if ([asset isEqual:[NSNull null]]) {
-                self.callback(@[@{@"errorCode": errOthers}]);
+                [picker dismissViewControllerAnimated:YES completion:^{
+                    self.callback(@[@{@"errorCode": errOthers}]);
+                }];
                 return;
             }
         }
@@ -579,7 +581,9 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
         [response setObject:assets forKey:@"assets"];
 
-        self.callback(@[response]);
+        [picker dismissViewControllerAnimated:YES completion:^{
+            self.callback(@[response]);
+        }];
     });
 }
 


### PR DESCRIPTION
## Motivation

Not waiting for the completion of the `PHPickerViewController` dismiss transition leads to issues when subsequently trying to take over the root view controller while the transition is still in progress, e.g. the app might freeze.

## Test Plan
1. Use `launchImageLibrary` or `launchCamera` and wait for the promise to resolve
2. Get the `rootViewController` and check if `presentedViewController` is `nil`
