### PR TITLE
Support iCloud Photos

### DIFF
--- a/ios/ImagePickerManager.mm
+++ b/ios/ImagePickerManager.mm
@@ -205,14 +205,12 @@ NSData* extractImageData(UIImage* image){
     if(phAsset){
         asset[@"timestamp"] = [self getDateTimeInUTC:phAsset.creationDate];
         asset[@"id"] = phAsset.localIdentifier;
-        // Add more extra data here ...
     }
 
     return asset;
 }
 
 CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIImageOrientation uiOrientation) {
-    //code from here: https://developer.apple.com/documentation/imageio/cgimagepropertyorientation?language=objc
     switch (uiOrientation) {
         case UIImageOrientationUp: return kCGImagePropertyOrientationUp;
         case UIImageOrientationDown: return kCGImagePropertyOrientationDown;
@@ -238,14 +236,11 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
     if (![url.URLByResolvingSymlinksInPath.path isEqualToString:videoDestinationURL.URLByResolvingSymlinksInPath.path]) {
         NSFileManager *fileManager = [NSFileManager defaultManager];
 
-        // Delete file if it already exists
         if ([fileManager fileExistsAtPath:videoDestinationURL.path]) {
             [fileManager removeItemAtURL:videoDestinationURL error:nil];
         }
 
-        if (url) { // Protect against reported crash
-
-          // If we have write access to the source file, move it. Otherwise use copy.
+        if (url) {
           if ([fileManager isWritableFileAtPath:[url path]]) {
             [fileManager moveItemAtURL:url toURL:videoDestinationURL error:error];
           } else {
@@ -308,7 +303,6 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         if(phAsset){
             response[@"timestamp"] = [self getDateTimeInUTC:phAsset.creationDate];
             response[@"id"] = phAsset.localIdentifier;
-            // Add more extra data here ...
         }
     }
 
@@ -437,7 +431,6 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(UIIma
         }
         photoSelected = YES;
 
-        // If include extra, we fetch the PHAsset, this required library permissions
         if([self.options[@"includeExtra"] boolValue]) {
           asset = [ImagePickerUtils fetchAssetFromImageInfo:info];
         }
@@ -526,7 +519,6 @@ API_AVAILABLE(ios(14))
         PHAsset *asset = nil;
         NSItemProvider *provider = result.itemProvider;
 
-        // If include extra, we fetch the PHAsset, this required library permissions
         if([self.options[@"includeExtra"] boolValue] && result.assetIdentifier != nil) {
             PHFetchResult* fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[result.assetIdentifier] options:nil];
             asset = fetchResult.firstObject;
@@ -536,9 +528,7 @@ API_AVAILABLE(ios(14))
 
         if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
             NSString *identifier = provider.registeredTypeIdentifiers.firstObject;
-            // Matches both com.apple.live-photo-bundle and com.apple.private.live-photo-bundle
             if ([identifier containsString:@"live-photo-bundle"]) {
-                // Handle live photos
                 identifier = @"public.jpeg";
             }
 
@@ -565,13 +555,11 @@ API_AVAILABLE(ios(14))
                 dispatch_group_leave(completionGroup);
             }];
         } else {
-            // The provider didn't have an item matching photo or video (fails on M1 Mac Simulator)
             dispatch_group_leave(completionGroup);
         }
     }];
 
     dispatch_group_notify(completionGroup, dispatch_get_main_queue(), ^{
-        //  mapVideoToAsset can fail and return nil, leaving asset NSNull.
         for (NSDictionary *asset in assets) {
             if ([asset isEqual:[NSNull null]]) {
                 self.callback(@[@{@"errorCode": errOthers}]);

--- a/ios/ImagePickerUtils.h
+++ b/ios/ImagePickerUtils.h
@@ -21,6 +21,26 @@
 
 + (NSString *) getFileSizeFromUrl:(NSURL *)url;
 
-+ (PHAsset *)fetchPHAssetOnIOS13:(NSDictionary<NSString *,id> *)info;
++ (PHAsset *)fetchAssetFromImageInfo:(NSDictionary<NSString *,id> *)info;
+
++ (BOOL)isAssetInICloud:(PHAsset *)asset;
+
++ (void)fetchImageFromICloudIfNeeded:(PHAsset *)asset 
+                         targetSize:(CGSize)targetSize 
+                        contentMode:(PHImageContentMode)contentMode 
+                            options:(PHImageRequestOptions *)options 
+                         completion:(void (^)(UIImage *image, NSDictionary *info, NSError *error))completion;
+
++ (void)fetchImageDataFromICloudIfNeeded:(PHAsset *)asset 
+                              options:(PHImageRequestOptions *)options 
+                           completion:(void (^)(NSData *imageData, NSString *dataUTI, UIImageOrientation orientation, NSDictionary *info, NSError *error))completion;
+
++ (NSData *)getImageDataHandlingICloud:(NSURL *)url phAsset:(PHAsset *)asset;
+
++ (void)getImageDataHandlingICloudAsync:(NSURL *)url 
+                                phAsset:(PHAsset *)asset 
+                             completion:(void (^)(NSData *imageData, NSError *error))completion;
+
++ (UIImageOrientation)UIImageOrientationFromCGImagePropertyOrientation:(CGImagePropertyOrientation)cgOrientation;
     
 @end

--- a/ios/ImagePickerUtils.mm
+++ b/ios/ImagePickerUtils.mm
@@ -176,14 +176,11 @@
 
 + (PHAsset *)fetchAssetFromImageInfo:(NSDictionary<NSString *,id> *)info
 {
-    // In iOS 14+, the best practice is to use PHPicker with assetIdentifier
-    // But if we're using UIImagePickerController and have a URL, we can attempt to find the asset
     NSURL *assetURL = info[UIImagePickerControllerImageURL];
     if (!assetURL) {
         return nil;
     }
     
-    // Try to get the asset based on the file path since we can't use ALAssetURLs anymore
     NSString *localID = [self getLocalIdentifierFromImageURL:assetURL];
     if (localID) {
         PHFetchResult* fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[localID] options:nil];
@@ -193,26 +190,21 @@
     return nil;
 }
 
-// Helper method to try to get local identifier from a file URL
 + (NSString *)getLocalIdentifierFromImageURL:(NSURL *)url
 {
     if (!url) {
         return nil;
     }
     
-    // Try to find matching assets in the photo library
     PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
     fetchOptions.predicate = [NSPredicate predicateWithFormat:@"mediaType == %d", PHAssetMediaTypeImage];
     
     __block NSString *localIdentifier = nil;
     
-    // Get the file name and create date to help narrow down the search
     NSString *fileName = url.lastPathComponent;
     
-    // Fetch all photo assets and look for a match
     PHFetchResult *result = [PHAsset fetchAssetsWithOptions:fetchOptions];
     [result enumerateObjectsUsingBlock:^(PHAsset *asset, NSUInteger idx, BOOL *stop) {
-        // Request the asset resource to get the file name
         PHAssetResource *resource = [[PHAssetResource assetResourcesForAsset:asset] firstObject];
         if ([resource.originalFilename isEqualToString:fileName]) {
             localIdentifier = asset.localIdentifier;


### PR DESCRIPTION
## Motivation (required)

- Removed conditional compilation for PHPicker support and added API availability for iOS 14.
- Updated permission checks for photo library access to include limited access.
- Refactored image fetching methods to handle iCloud assets more effectively.
- Introduced new utility methods for fetching image data and handling iCloud scenarios.

## Test Plan (required)
Select iCloud offload photos